### PR TITLE
docs: add per-client MCP install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,42 @@ For most MCP clients, the config is:
 }
 ```
 
-Common config locations:
+### Install command by client
+
+**Claude Code**
+
+```bash
+claude mcp add --scope user octen -e OCTEN_API_KEY=your-key-here -- npx -y octen-mcp
+```
+
+**Codex**
+
+```bash
+codex mcp add octen --env OCTEN_API_KEY=your-key-here -- npx -y octen-mcp
+```
+
+**Gemini CLI**
+
+```bash
+gemini mcp add octen -e OCTEN_API_KEY=your-key-here -- npx -y octen-mcp
+```
+
+**VS Code** (or click a badge above)
+
+```bash
+code --add-mcp '{"name":"octen","command":"npx","args":["-y","octen-mcp"],"env":{"OCTEN_API_KEY":"your-key-here"}}'
+```
+
+**Cursor** — [Add to Cursor](https://cursor.com/en/install-mcp?name=octen&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIm9jdGVuLW1jcCJdLCJlbnYiOnsiT0NURU5fQVBJX0tFWSI6InlvdXIta2V5LWhlcmUifX0%3D) (edit the key afterwards), or use the JSON above in `~/.cursor/mcp.json`.
+
+### Config file locations
+
+For clients without a CLI installer, drop the JSON config above into:
 
 - **Claude Desktop**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Cursor**: `~/.cursor/mcp.json`
-- **VS Code workspace**: `.vscode/mcp.json` using `servers` instead of `mcpServers`
-- **Windsurf / Cline / other clients**: use the same command and env var in that client's MCP settings
-
-For Claude Code:
-
-```bash
-claude mcp add --scope user octen \
-  -e OCTEN_API_KEY=your-key-here \
-  -- npx -y octen-mcp
-```
+- **VS Code workspace**: `.vscode/mcp.json` (use `servers` instead of `mcpServers`)
+- **Windsurf / Cline / other clients**: paste it into that client's MCP settings
 
 ## Tools
 


### PR DESCRIPTION
## Summary
Quick start previously listed only the **Claude Code** CLI command. This adds copy-paste install commands for the other major agents and reorganizes the section.

New section **Install command by client**:
- **Claude Code** — `claude mcp add ... -- npx -y octen-mcp`
- **Codex** — `codex mcp add octen --env ... -- npx -y octen-mcp`
- **Gemini CLI** — `gemini mcp add octen -e ... -- npx -y octen-mcp`
- **VS Code** — `code --add-mcp '{...}'` (plus the existing badges)
- **Cursor** — one-click `cursor.com/en/install-mcp` link + `~/.cursor/mcp.json`

Plus a **Config file locations** block for clients without a CLI installer (Claude Desktop, Windsurf, Cline, VS Code workspace).

## Sources (each command verified, not guessed)
- `claude` / `codex`: exact syntax from their local `mcp add --help`.
- `gemini`: from upstream `google-gemini/gemini-cli` `docs/tools/mcp-server.md`.
- `code --add-mcp`: from VS Code official docs.
- Cursor `config` param confirmed to be base64-encoded JSON (decoded a known-good example); the link's payload decodes to the octen stdio config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)