### PR TITLE
chore: release v0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octen-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octen-mcp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version 0.2.1 → 0.2.2 to publish the clarified `extract` `query`-parameter guidance (PR #5) to npm clients.
- Description-only change in the released code; bumping is required because MCP tool descriptions are baked into the npm package and clients only see them after a release.

## Release steps (after merge)
- [ ] Tag `v0.2.2` on the merge commit and push → triggers `publish.yml` (npm publish + GitHub Release).