### PR TITLE
docs(readme): escape space in Claude Desktop config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For most MCP clients, the config is:
 
 For clients without a CLI installer, drop the JSON config above into:
 
-- **Claude Desktop**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Claude Desktop**: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
 - **Cursor**: `~/.cursor/mcp.json`
 - **VS Code workspace**: `.vscode/mcp.json` (use `servers` instead of `mcpServers`)
 - **Windsurf / Cline / other clients**: paste it into that client's MCP settings


### PR DESCRIPTION
## Summary
- The Claude Desktop config path `~/Library/Application Support/...` had an unescaped space. Copy-pasting it into a terminal splits on the space and fails with "no such file".
- Backslash-escape the space (`Application\ Support`) so the path is safe to paste into a shell, while `~` still expands.

README-only change.

## Test plan
- [x] `~/Library/Application\ Support/Claude/claude_desktop_config.json` resolves correctly when pasted into zsh/bash