### PR TITLE
feat: add image_search + video_search tools (beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Core capabilities:
 
 - **`search` / `news_search`**: search the live web with domain, text, and time filters.
 - **`extract`**: turn one or more URLs into clean, LLM-ready content.
+- **`image_search`** (In Beta — contact us for beta access): search the web for images by text query, optionally with a reference image.
+- **`video_search`** (In Beta — contact us for beta access): search the web for videos by text query.
 
 What makes Octen useful for agents is that `extract` returns more than page text. Each successful result also includes:
 
@@ -84,6 +86,8 @@ For clients without a CLI installer, drop the JSON config above into:
 | `search` | Search the live web with domain, text, time, and content controls | broad web search |
 | `news_search` | Same engine as `search`, fixed to news | current events and timely reporting |
 | `extract` | Fetch 1-20 URLs and return clean content, labels, and optional highlights | summarization, RAG, fact lookup |
+| `image_search` | _In Beta — contact us for beta access._ Search the web for images by text query (optional reference `image_url`) | finding pictures, photos, visual references |
+| `video_search` | _In Beta — contact us for beta access._ Search the web for videos by text query | finding videos, clips, footage |
 
 Reference docs:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.2.2",
+  "version": "0.4.0",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",

--- a/src/imageSearch.ts
+++ b/src/imageSearch.ts
@@ -1,0 +1,238 @@
+/**
+ * `image_search` tool — wraps Octen Image Search API (POST /image-search).
+ *
+ * Invite-only beta. Surfaced to the LLM as an image-search tool: it takes a
+ * text `query` (and an optional reference `image_url`) and returns ranked
+ * images (title, source page, dimensions, thumbnail, description, summary).
+ *
+ * The underlying API accepts a multimodal `inputs` array of
+ * `{type, url|data}` entries. We FLATTEN that for the LLM: a top-level
+ * `query` string becomes `{type:"text", data:query}` and an optional
+ * `image_url` becomes `{type:"image", url:image_url}`.
+ *
+ * Same envelope (`{code, msg, request_id, data, meta}`) and `x-api-key` auth
+ * as search; `meta` sits at the top level (sibling of `data`).
+ */
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { formatMeta, errorResult } from "./search.js";
+
+const DEFAULT_API_BASE = process.env.OCTEN_API_URL ?? "https://api.octen.ai";
+const API_KEY = process.env.OCTEN_API_KEY;
+
+/** Tool advertisement — clients see this in the list-tools response. */
+export const imageSearchTool: Tool = {
+  name: "image_search",
+  description:
+    "In Beta. Contact us to request beta access. Search the live web for " +
+    "images with Octen and return ranked results (title, source page, " +
+    "dimensions, thumbnail, description, summary). Pass a text `query`, and " +
+    "optionally an `image_url` to search by reference image. Set `topic` to " +
+    "`design` for design/illustration-oriented results. Use this when the " +
+    "user wants to find pictures, photos, diagrams, or visual references — " +
+    "not for general text web search.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Text query describing the images to find.",
+      },
+      image_url: {
+        type: "string",
+        description:
+          "Optional public image URL to search by reference image (visual " +
+          "similarity), in addition to the text `query`.",
+      },
+      topic: {
+        type: "string",
+        enum: ["general", "design"],
+        default: "general",
+        description:
+          "Image category: `general` for broad image search, `design` for " +
+          "design / illustration oriented results. Default general.",
+      },
+      count: {
+        type: "integer",
+        minimum: 1,
+        maximum: 10,
+        default: 5,
+        description: "Number of results to return (1-10). Default 5.",
+      },
+      include_domains: {
+        type: "array",
+        items: { type: "string" },
+        description: "Only return results from these domains (e.g. 'unsplash.com').",
+      },
+      exclude_domains: {
+        type: "array",
+        items: { type: "string" },
+        description: "Drop results from these domains.",
+      },
+      time_range: {
+        type: "string",
+        enum: ["day", "week", "month", "year", "d", "w", "m", "y"],
+        description:
+          "Relative time window (e.g. `week`, `month`). Mutually exclusive with " +
+          "`start_time`/`end_time` — if both are given, the absolute range wins.",
+      },
+      start_time: {
+        type: "string",
+        description: "Lower bound for the time window, ISO 8601 (e.g. '2025-01-01T00:00:00Z').",
+      },
+      end_time: {
+        type: "string",
+        description: "Upper bound for the time window, ISO 8601.",
+      },
+      safesearch: {
+        type: "string",
+        enum: ["off", "strict"],
+        default: "strict",
+        description: "Adult-content filter. Default strict.",
+      },
+      html_snippet: {
+        type: "object",
+        description:
+          "Return an HTML snippet of the source context per result. Omit to use " +
+          "the server default.",
+        properties: {
+          enable: { type: "boolean", description: "Whether to return HTML snippets." },
+          max_tokens: {
+            type: "integer",
+            minimum: 100,
+            default: 5000,
+            description: "Max tokens per HTML snippet (min 100). Default 5000.",
+          },
+        },
+      },
+      timeout: {
+        type: "integer",
+        minimum: 1,
+        maximum: 60,
+        description: "Request timeout in seconds (1-60).",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+interface HtmlSnippetOptions {
+  enable?: boolean;
+  max_tokens?: number;
+}
+
+interface ImageSearchArgs {
+  query: string;
+  image_url?: string;
+  topic?: "general" | "design";
+  count?: number;
+  include_domains?: string[];
+  exclude_domains?: string[];
+  time_range?: "day" | "week" | "month" | "year" | "d" | "w" | "m" | "y";
+  start_time?: string;
+  end_time?: string;
+  safesearch?: "off" | "strict";
+  html_snippet?: HtmlSnippetOptions;
+  timeout?: number;
+}
+
+/** Handler — POSTs to Octen Image Search and reshapes the response for the LLM. */
+export async function handleImageSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+  const args = rawArgs as unknown as ImageSearchArgs;
+
+  if (typeof args.query !== "string" || args.query.trim().length === 0) {
+    return errorResult("`query` must be a non-empty string");
+  }
+  if (!API_KEY) {
+    return errorResult(
+      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
+      "and add it to your MCP client config (see README)."
+    );
+  }
+
+  // `timeout` is an HTTP-client concern; `query`/`image_url` are flattened into `inputs`.
+  const { timeout, query, image_url, ...payloadArgs } = args;
+
+  // Build the multimodal inputs array from the flattened fields.
+  const inputs: Array<Record<string, unknown>> = [{ type: "text", data: query }];
+  if (typeof image_url === "string" && image_url.length > 0) {
+    inputs.push({ type: "image", url: image_url });
+  }
+
+  // Drop undefined fields so server defaults apply.
+  const body: Record<string, unknown> = { inputs };
+  for (const [key, value] of Object.entries(payloadArgs)) {
+    if (value !== undefined) body[key] = value;
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${DEFAULT_API_BASE}/image-search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY,
+      },
+      body: JSON.stringify(body),
+      signal: timeout ? AbortSignal.timeout(timeout * 1000) : undefined,
+    });
+  } catch (e) {
+    const err = e as Error;
+    if (err.name === "TimeoutError") {
+      return errorResult(`Octen Image Search timed out after ${timeout}s`);
+    }
+    return errorResult(`Network error calling Octen Image Search: ${err.message}`);
+  }
+
+  // Octen returns the envelope even on errors (code: 401, 429, etc.),
+  // so we read the body regardless of HTTP status.
+  let data: any;
+  try {
+    data = await resp.json();
+  } catch {
+    return errorResult(`Octen Image Search returned non-JSON (HTTP ${resp.status})`);
+  }
+
+  // Envelope-level error: surface code + msg verbatim.
+  if (typeof data?.code === "number" && data.code !== 0) {
+    return errorResult(
+      `Octen Image Search: code=${data.code} msg=${data.msg ?? "(no msg)"}` +
+      (data.request_id ? ` request_id=${data.request_id}` : "")
+    );
+  }
+
+  const results = data?.data?.results ?? [];
+  const meta = data?.meta ?? {};
+  const total = results.length;
+
+  if (total === 0) {
+    return { content: [{ type: "text", text: `No image results for "${args.query}".` }] };
+  }
+
+  const blocks = results.map((r: any, i: number) => formatResult(r, i + 1, total));
+  const metaLine = formatMeta(meta, data?.request_id);
+  const text = [...blocks, metaLine].filter(Boolean).join("\n\n---\n\n");
+
+  return { content: [{ type: "text", text }] };
+}
+
+function formatResult(r: any, idx: number, total: number): string {
+  const lines: string[] = [`## Result ${idx}/${total}: ${r.title ?? "(untitled)"}`];
+  if (r.url) lines.push(r.url);
+  if (r.source_page) lines.push(`**Source page:** ${r.source_page}`);
+  if (typeof r.width === "number" && typeof r.height === "number") {
+    lines.push(`**Dimensions:** ${r.width}x${r.height}`);
+  }
+  if (r.thumbnail) lines.push(`**Thumbnail:** ${r.thumbnail}`);
+  if (r.time_published) lines.push(`**Published:** ${r.time_published}`);
+  if (r.time_last_crawled) lines.push(`**Last crawled:** ${r.time_last_crawled}`);
+  if (typeof r.description === "string" && r.description.length > 0) {
+    lines.push(`\n### Description\n${r.description}`);
+  }
+  if (typeof r.summary === "string" && r.summary.length > 0) {
+    lines.push(`\n### Summary\n${r.summary}`);
+  }
+  if (typeof r.html_snippet === "string" && r.html_snippet.length > 0) {
+    lines.push(`**HTML snippet:** present (${r.html_snippet.length} chars)`);
+  }
+  return lines.join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,13 @@ import {
 
 import { extractTool, handleExtract } from "./extract.js";
 import { searchTool, handleSearch, newsSearchTool, handleNewsSearch } from "./search.js";
+import { imageSearchTool, handleImageSearch } from "./imageSearch.js";
+import { videoSearchTool, handleVideoSearch } from "./videoSearch.js";
 
 const server = new Server(
   {
     name: "octen-mcp",
-    version: "0.2.0",
+    version: "0.4.0",
   },
   {
     capabilities: {
@@ -30,7 +32,7 @@ const server = new Server(
 
 // 1. List available tools — clients call this first to discover what we offer.
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [searchTool, newsSearchTool, extractTool],
+  tools: [searchTool, newsSearchTool, extractTool, imageSearchTool, videoSearchTool],
 }));
 
 // 2. Dispatch tool calls.
@@ -44,6 +46,10 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       return await handleNewsSearch(args ?? {});
     case "extract":
       return await handleExtract(args ?? {});
+    case "image_search":
+      return await handleImageSearch(args ?? {});
+    case "video_search":
+      return await handleVideoSearch(args ?? {});
     default:
       // MCP convention: return an error result, don't throw.
       return {

--- a/src/search.ts
+++ b/src/search.ts
@@ -320,7 +320,7 @@ function formatResult(r: any, idx: number, total: number): string {
   return lines.join("\n");
 }
 
-function formatMeta(meta: any, requestId: string | undefined): string {
+export function formatMeta(meta: any, requestId: string | undefined): string {
   const parts: string[] = [];
   const u = meta?.usage;
   if (u && typeof u === "object") {
@@ -336,6 +336,6 @@ function formatMeta(meta: any, requestId: string | undefined): string {
   return parts.length ? `_${parts.join(" · ")}_` : "";
 }
 
-function errorResult(msg: string): CallToolResult {
+export function errorResult(msg: string): CallToolResult {
   return { isError: true, content: [{ type: "text", text: msg }] };
 }

--- a/src/videoSearch.ts
+++ b/src/videoSearch.ts
@@ -1,0 +1,182 @@
+/**
+ * `video_search` tool — wraps Octen Video Search API (POST /video-search).
+ *
+ * Invite-only beta. Surfaced to the LLM as a video-search tool: it takes a
+ * text `query` and returns ranked videos (title, source page, cover image,
+ * duration, matching segment, authors, description).
+ *
+ * The underlying API accepts a TEXT-ONLY `inputs` array. We FLATTEN that for
+ * the LLM: a top-level `query` string becomes `[{type:"text", data:query}]`.
+ *
+ * Same envelope (`{code, msg, request_id, data, meta}`) and `x-api-key` auth
+ * as search; `meta` sits at the top level (sibling of `data`).
+ */
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { formatMeta, errorResult } from "./search.js";
+
+const DEFAULT_API_BASE = process.env.OCTEN_API_URL ?? "https://api.octen.ai";
+const API_KEY = process.env.OCTEN_API_KEY;
+
+/** Tool advertisement — clients see this in the list-tools response. */
+export const videoSearchTool: Tool = {
+  name: "video_search",
+  description:
+    "In Beta. Contact us to request beta access. Search the live web for " +
+    "videos with Octen and return ranked results (title, source page, cover " +
+    "image, duration, matching segment, authors, description). Pass a text " +
+    "`query`. Use this when the user wants to find videos, clips, or footage " +
+    "— not for general text web search.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Text query describing the videos to find.",
+      },
+      count: {
+        type: "integer",
+        minimum: 1,
+        maximum: 10,
+        default: 5,
+        description: "Number of results to return (1-10). Default 5.",
+      },
+      time_range: {
+        type: "string",
+        enum: ["day", "week", "month", "year", "d", "w", "m", "y"],
+        description:
+          "Relative time window (e.g. `week`, `month`). Mutually exclusive with " +
+          "`start_time`/`end_time` — if both are given, the absolute range wins.",
+      },
+      start_time: {
+        type: "string",
+        description: "Lower bound for the time window, ISO 8601 (e.g. '2025-01-01T00:00:00Z').",
+      },
+      end_time: {
+        type: "string",
+        description: "Upper bound for the time window, ISO 8601.",
+      },
+      safesearch: {
+        type: "string",
+        enum: ["off", "strict"],
+        default: "strict",
+        description: "Adult-content filter. Default strict.",
+      },
+      timeout: {
+        type: "integer",
+        minimum: 1,
+        maximum: 60,
+        description: "Request timeout in seconds (1-60).",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+interface VideoSearchArgs {
+  query: string;
+  count?: number;
+  time_range?: "day" | "week" | "month" | "year" | "d" | "w" | "m" | "y";
+  start_time?: string;
+  end_time?: string;
+  safesearch?: "off" | "strict";
+  timeout?: number;
+}
+
+/** Handler — POSTs to Octen Video Search and reshapes the response for the LLM. */
+export async function handleVideoSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+  const args = rawArgs as unknown as VideoSearchArgs;
+
+  if (typeof args.query !== "string" || args.query.trim().length === 0) {
+    return errorResult("`query` must be a non-empty string");
+  }
+  if (!API_KEY) {
+    return errorResult(
+      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
+      "and add it to your MCP client config (see README)."
+    );
+  }
+
+  // `timeout` is an HTTP-client concern; `query` is flattened into `inputs` (text only).
+  const { timeout, query, ...payloadArgs } = args;
+
+  const inputs: Array<Record<string, unknown>> = [{ type: "text", data: query }];
+
+  // Drop undefined fields so server defaults apply.
+  const body: Record<string, unknown> = { inputs };
+  for (const [key, value] of Object.entries(payloadArgs)) {
+    if (value !== undefined) body[key] = value;
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${DEFAULT_API_BASE}/video-search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY,
+      },
+      body: JSON.stringify(body),
+      signal: timeout ? AbortSignal.timeout(timeout * 1000) : undefined,
+    });
+  } catch (e) {
+    const err = e as Error;
+    if (err.name === "TimeoutError") {
+      return errorResult(`Octen Video Search timed out after ${timeout}s`);
+    }
+    return errorResult(`Network error calling Octen Video Search: ${err.message}`);
+  }
+
+  // Octen returns the envelope even on errors (code: 401, 429, etc.),
+  // so we read the body regardless of HTTP status.
+  let data: any;
+  try {
+    data = await resp.json();
+  } catch {
+    return errorResult(`Octen Video Search returned non-JSON (HTTP ${resp.status})`);
+  }
+
+  // Envelope-level error: surface code + msg verbatim.
+  if (typeof data?.code === "number" && data.code !== 0) {
+    return errorResult(
+      `Octen Video Search: code=${data.code} msg=${data.msg ?? "(no msg)"}` +
+      (data.request_id ? ` request_id=${data.request_id}` : "")
+    );
+  }
+
+  const results = data?.data?.results ?? [];
+  const meta = data?.meta ?? {};
+  const total = results.length;
+
+  if (total === 0) {
+    return { content: [{ type: "text", text: `No video results for "${args.query}".` }] };
+  }
+
+  const blocks = results.map((r: any, i: number) => formatResult(r, i + 1, total));
+  const metaLine = formatMeta(meta, data?.request_id);
+  const text = [...blocks, metaLine].filter(Boolean).join("\n\n---\n\n");
+
+  return { content: [{ type: "text", text }] };
+}
+
+function formatResult(r: any, idx: number, total: number): string {
+  const lines: string[] = [`## Result ${idx}/${total}: ${r.title ?? "(untitled)"}`];
+  if (r.url) lines.push(r.url);
+  if (r.source_page) lines.push(`**Source page:** ${r.source_page}`);
+  if (r.cover_url) lines.push(`**Cover:** ${r.cover_url}`);
+  if (typeof r.duration_seconds === "number") lines.push(`**Duration:** ${r.duration_seconds}s`);
+  const seg = r.match_segment;
+  if (seg && typeof seg === "object" &&
+      (typeof seg.start_seconds === "number" || typeof seg.end_seconds === "number")) {
+    lines.push(`**Match segment:** ${seg.start_seconds ?? "?"}s–${seg.end_seconds ?? "?"}s`);
+  }
+  if (r.authors) {
+    const authors = Array.isArray(r.authors) ? r.authors.join(", ") : r.authors;
+    lines.push(`**Authors:** ${authors}`);
+  }
+  if (r.time_published) lines.push(`**Published:** ${r.time_published}`);
+  if (r.time_last_crawled) lines.push(`**Last crawled:** ${r.time_last_crawled}`);
+  if (typeof r.description === "string" && r.description.length > 0) {
+    lines.push(`\n### Description\n${r.description}`);
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- Add `image_search` tool (flattened `query` + optional `image_url`; `topic`, `count`, `html_snippet`, filters) → `POST /image-search`.
- Add `video_search` tool (text `query`; `count`, time/safesearch filters) → `POST /video-search`.
- Both are **invite-only beta** — tool descriptions begin with "In Beta. Contact us to request beta access."
- Register in ListTools + dispatch; bump server version string + package to **0.4.0**.

## Test plan
- [x] `npm run build`; `tools/list` shows `image_search` + `video_search` with correct flattened schemas
- [x] Live e2e: `tools/call image_search` (source_page/dimensions) and `video_search` (cover/duration/match segment) render correctly, no error

> Note: version 0.4.0 assumes broad-search PR #8 (0.3.0) merges first.