### PR TITLE
feat: search suite — broad_search + image_search + video_search tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-06-29
+
+### Added
+- `broad_search` tool wrapping Octen Broad Search (`POST /broad-search`) —
+  decomposes a query into up to `max_queries` (1–30, default 5) sub-queries,
+  searches them concurrently, and returns results grouped per sub-query. Accepts
+  the same per-sub-query options as `search` (flattened, assembled into
+  `search_options`).
+- `image_search` tool wrapping Octen Image Search (`POST /image-search`) —
+  flattened `query` + optional `image_url`, `topic` (general/design; `design`
+  returns a style `summary` + `html_snippet`), `count` (1–10), domain/time
+  filters, `safesearch`, `html_snippet`. **In Beta — contact us for beta access.**
+- `video_search` tool wrapping Octen Video Search (`POST /video-search`) — text
+  `query`, `count` (1–10), time filters, `safesearch`; results include the matched
+  segment timestamps, duration, cover, and source. **In Beta — contact us for beta access.**
+
 ## [0.2.0] — 2026-06-23
 
 ### Added
@@ -73,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OCTEN_API_KEY` env var for authentication.
 - `OCTEN_API_URL` override for staging or self-hosted endpoints.
 
-[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Octen-Team/octen-mcp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Octen-Team/octen-mcp/releases/tag/v0.2.0
 [0.1.5]: https://github.com/Octen-Team/octen-mcp/releases/tag/v0.1.5
 [0.1.4]: https://github.com/Octen-Team/octen-mcp/releases/tag/v0.1.4

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ MCP server for **Octen**. Plug it into Claude, Cursor, VS Code, Windsurf, or any
 Core capabilities:
 
 - **`search` / `news_search`**: search the live web with domain, text, and time filters.
+- **`broad_search`**: decompose a query into multiple sub-queries, search them concurrently, and return results grouped per sub-query for broad coverage.
 - **`extract`**: turn one or more URLs into clean, LLM-ready content.
 
 What makes Octen useful for agents is that `extract` returns more than page text. Each successful result also includes:
@@ -81,8 +82,9 @@ For clients without a CLI installer, drop the JSON config above into:
 
 | Tool | What it does | Best for |
 |---|---|---|
-| `search` | Search the live web with domain, text, time, and content controls | broad web search |
+| `search` | Search the live web with domain, text, time, and content controls | a single focused web search |
 | `news_search` | Same engine as `search`, fixed to news | current events and timely reporting |
+| `broad_search` | Decompose a query into up to `max_queries` sub-queries, search concurrently, return grouped results | research-style, multi-angle coverage |
 | `extract` | Fetch 1-20 URLs and return clean content, labels, and optional highlights | summarization, RAG, fact lookup |
 
 Reference docs:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Core capabilities:
 
 - **`search` / `news_search`**: search the live web with domain, text, and time filters.
 - **`extract`**: turn one or more URLs into clean, LLM-ready content.
+- **`image_search`** (In Beta — contact us for beta access): search the web for images by text query, optionally with a reference image.
+- **`video_search`** (In Beta — contact us for beta access): search the web for videos by text query.
 
 What makes Octen useful for agents is that `extract` returns more than page text. Each successful result also includes:
 
@@ -84,6 +86,8 @@ For clients without a CLI installer, drop the JSON config above into:
 | `search` | Search the live web with domain, text, time, and content controls | broad web search |
 | `news_search` | Same engine as `search`, fixed to news | current events and timely reporting |
 | `extract` | Fetch 1-20 URLs and return clean content, labels, and optional highlights | summarization, RAG, fact lookup |
+| `image_search` | _In Beta — contact us for beta access._ Search the web for images by text query (optional reference `image_url`) | finding pictures, photos, visual references |
+| `video_search` | _In Beta — contact us for beta access._ Search the web for videos by text query | finding videos, clips, footage |
 
 Reference docs:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.2.2",
+  "version": "0.4.0",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",

--- a/src/imageSearch.ts
+++ b/src/imageSearch.ts
@@ -27,9 +27,10 @@ export const imageSearchTool: Tool = {
     "images with Octen and return ranked results (title, source page, " +
     "dimensions, thumbnail, description, summary). Pass a text `query`, and " +
     "optionally an `image_url` to search by reference image. Set `topic` to " +
-    "`design` for design/illustration-oriented results. Use this when the " +
-    "user wants to find pictures, photos, diagrams, or visual references — " +
-    "not for general text web search.",
+    "`design` for UI design references — each result then carries a structured " +
+    "style `summary` and an `html_snippet` for building/restyling frontends. " +
+    "Use this when the user wants to find pictures, photos, diagrams, or visual " +
+    "references — not for general text web search.",
   inputSchema: {
     type: "object",
     properties: {

--- a/src/imageSearch.ts
+++ b/src/imageSearch.ts
@@ -36,6 +36,7 @@ export const imageSearchTool: Tool = {
     properties: {
       query: {
         type: "string",
+        maxLength: 500,
         description: "Text query describing the images to find.",
       },
       image_url: {

--- a/src/imageSearch.ts
+++ b/src/imageSearch.ts
@@ -1,0 +1,238 @@
+/**
+ * `image_search` tool — wraps Octen Image Search API (POST /image-search).
+ *
+ * Invite-only beta. Surfaced to the LLM as an image-search tool: it takes a
+ * text `query` (and an optional reference `image_url`) and returns ranked
+ * images (title, source page, dimensions, thumbnail, description, summary).
+ *
+ * The underlying API accepts a multimodal `inputs` array of
+ * `{type, url|data}` entries. We FLATTEN that for the LLM: a top-level
+ * `query` string becomes `{type:"text", data:query}` and an optional
+ * `image_url` becomes `{type:"image", url:image_url}`.
+ *
+ * Same envelope (`{code, msg, request_id, data, meta}`) and `x-api-key` auth
+ * as search; `meta` sits at the top level (sibling of `data`).
+ */
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { formatMeta, errorResult } from "./search.js";
+
+const DEFAULT_API_BASE = process.env.OCTEN_API_URL ?? "https://api.octen.ai";
+const API_KEY = process.env.OCTEN_API_KEY;
+
+/** Tool advertisement — clients see this in the list-tools response. */
+export const imageSearchTool: Tool = {
+  name: "image_search",
+  description:
+    "In Beta. Contact us to request beta access. Search the live web for " +
+    "images with Octen and return ranked results (title, source page, " +
+    "dimensions, thumbnail, description, summary). Pass a text `query`, and " +
+    "optionally an `image_url` to search by reference image. Set `topic` to " +
+    "`design` for design/illustration-oriented results. Use this when the " +
+    "user wants to find pictures, photos, diagrams, or visual references — " +
+    "not for general text web search.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Text query describing the images to find.",
+      },
+      image_url: {
+        type: "string",
+        description:
+          "Optional public image URL to search by reference image (visual " +
+          "similarity), in addition to the text `query`.",
+      },
+      topic: {
+        type: "string",
+        enum: ["general", "design"],
+        default: "general",
+        description:
+          "Image category: `general` for broad image search, `design` for " +
+          "design / illustration oriented results. Default general.",
+      },
+      count: {
+        type: "integer",
+        minimum: 1,
+        maximum: 10,
+        default: 5,
+        description: "Number of results to return (1-10). Default 5.",
+      },
+      include_domains: {
+        type: "array",
+        items: { type: "string" },
+        description: "Only return results from these domains (e.g. 'unsplash.com').",
+      },
+      exclude_domains: {
+        type: "array",
+        items: { type: "string" },
+        description: "Drop results from these domains.",
+      },
+      time_range: {
+        type: "string",
+        enum: ["day", "week", "month", "year", "d", "w", "m", "y"],
+        description:
+          "Relative time window (e.g. `week`, `month`). Mutually exclusive with " +
+          "`start_time`/`end_time` — if both are given, the absolute range wins.",
+      },
+      start_time: {
+        type: "string",
+        description: "Lower bound for the time window, ISO 8601 (e.g. '2025-01-01T00:00:00Z').",
+      },
+      end_time: {
+        type: "string",
+        description: "Upper bound for the time window, ISO 8601.",
+      },
+      safesearch: {
+        type: "string",
+        enum: ["off", "strict"],
+        default: "strict",
+        description: "Adult-content filter. Default strict.",
+      },
+      html_snippet: {
+        type: "object",
+        description:
+          "Return an HTML snippet of the source context per result. Omit to use " +
+          "the server default.",
+        properties: {
+          enable: { type: "boolean", description: "Whether to return HTML snippets." },
+          max_tokens: {
+            type: "integer",
+            minimum: 100,
+            default: 5000,
+            description: "Max tokens per HTML snippet (min 100). Default 5000.",
+          },
+        },
+      },
+      timeout: {
+        type: "integer",
+        minimum: 1,
+        maximum: 60,
+        description: "Request timeout in seconds (1-60).",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+interface HtmlSnippetOptions {
+  enable?: boolean;
+  max_tokens?: number;
+}
+
+interface ImageSearchArgs {
+  query: string;
+  image_url?: string;
+  topic?: "general" | "design";
+  count?: number;
+  include_domains?: string[];
+  exclude_domains?: string[];
+  time_range?: "day" | "week" | "month" | "year" | "d" | "w" | "m" | "y";
+  start_time?: string;
+  end_time?: string;
+  safesearch?: "off" | "strict";
+  html_snippet?: HtmlSnippetOptions;
+  timeout?: number;
+}
+
+/** Handler — POSTs to Octen Image Search and reshapes the response for the LLM. */
+export async function handleImageSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+  const args = rawArgs as unknown as ImageSearchArgs;
+
+  if (typeof args.query !== "string" || args.query.trim().length === 0) {
+    return errorResult("`query` must be a non-empty string");
+  }
+  if (!API_KEY) {
+    return errorResult(
+      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
+      "and add it to your MCP client config (see README)."
+    );
+  }
+
+  // `timeout` is an HTTP-client concern; `query`/`image_url` are flattened into `inputs`.
+  const { timeout, query, image_url, ...payloadArgs } = args;
+
+  // Build the multimodal inputs array from the flattened fields.
+  const inputs: Array<Record<string, unknown>> = [{ type: "text", data: query }];
+  if (typeof image_url === "string" && image_url.length > 0) {
+    inputs.push({ type: "image", url: image_url });
+  }
+
+  // Drop undefined fields so server defaults apply.
+  const body: Record<string, unknown> = { inputs };
+  for (const [key, value] of Object.entries(payloadArgs)) {
+    if (value !== undefined) body[key] = value;
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${DEFAULT_API_BASE}/image-search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY,
+      },
+      body: JSON.stringify(body),
+      signal: timeout ? AbortSignal.timeout(timeout * 1000) : undefined,
+    });
+  } catch (e) {
+    const err = e as Error;
+    if (err.name === "TimeoutError") {
+      return errorResult(`Octen Image Search timed out after ${timeout}s`);
+    }
+    return errorResult(`Network error calling Octen Image Search: ${err.message}`);
+  }
+
+  // Octen returns the envelope even on errors (code: 401, 429, etc.),
+  // so we read the body regardless of HTTP status.
+  let data: any;
+  try {
+    data = await resp.json();
+  } catch {
+    return errorResult(`Octen Image Search returned non-JSON (HTTP ${resp.status})`);
+  }
+
+  // Envelope-level error: surface code + msg verbatim.
+  if (typeof data?.code === "number" && data.code !== 0) {
+    return errorResult(
+      `Octen Image Search: code=${data.code} msg=${data.msg ?? "(no msg)"}` +
+      (data.request_id ? ` request_id=${data.request_id}` : "")
+    );
+  }
+
+  const results = data?.data?.results ?? [];
+  const meta = data?.meta ?? {};
+  const total = results.length;
+
+  if (total === 0) {
+    return { content: [{ type: "text", text: `No image results for "${args.query}".` }] };
+  }
+
+  const blocks = results.map((r: any, i: number) => formatResult(r, i + 1, total));
+  const metaLine = formatMeta(meta, data?.request_id);
+  const text = [...blocks, metaLine].filter(Boolean).join("\n\n---\n\n");
+
+  return { content: [{ type: "text", text }] };
+}
+
+function formatResult(r: any, idx: number, total: number): string {
+  const lines: string[] = [`## Result ${idx}/${total}: ${r.title ?? "(untitled)"}`];
+  if (r.url) lines.push(r.url);
+  if (r.source_page) lines.push(`**Source page:** ${r.source_page}`);
+  if (typeof r.width === "number" && typeof r.height === "number") {
+    lines.push(`**Dimensions:** ${r.width}x${r.height}`);
+  }
+  if (r.thumbnail) lines.push(`**Thumbnail:** ${r.thumbnail}`);
+  if (r.time_published) lines.push(`**Published:** ${r.time_published}`);
+  if (r.time_last_crawled) lines.push(`**Last crawled:** ${r.time_last_crawled}`);
+  if (typeof r.description === "string" && r.description.length > 0) {
+    lines.push(`\n### Description\n${r.description}`);
+  }
+  if (typeof r.summary === "string" && r.summary.length > 0) {
+    lines.push(`\n### Summary\n${r.summary}`);
+  }
+  if (typeof r.html_snippet === "string" && r.html_snippet.length > 0) {
+    lines.push(`**HTML snippet:** present (${r.html_snippet.length} chars)`);
+  }
+  return lines.join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,13 @@ import {
 
 import { extractTool, handleExtract } from "./extract.js";
 import { searchTool, handleSearch, newsSearchTool, handleNewsSearch } from "./search.js";
+import { imageSearchTool, handleImageSearch } from "./imageSearch.js";
+import { videoSearchTool, handleVideoSearch } from "./videoSearch.js";
 
 const server = new Server(
   {
     name: "octen-mcp",
-    version: "0.2.0",
+    version: "0.4.0",
   },
   {
     capabilities: {
@@ -30,7 +32,7 @@ const server = new Server(
 
 // 1. List available tools — clients call this first to discover what we offer.
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [searchTool, newsSearchTool, extractTool],
+  tools: [searchTool, newsSearchTool, extractTool, imageSearchTool, videoSearchTool],
 }));
 
 // 2. Dispatch tool calls.
@@ -44,6 +46,10 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       return await handleNewsSearch(args ?? {});
     case "extract":
       return await handleExtract(args ?? {});
+    case "image_search":
+      return await handleImageSearch(args ?? {});
+    case "video_search":
+      return await handleVideoSearch(args ?? {});
     default:
       // MCP convention: return an error result, don't throw.
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,19 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { extractTool, handleExtract } from "./extract.js";
-import { searchTool, handleSearch, newsSearchTool, handleNewsSearch } from "./search.js";
+import {
+  searchTool,
+  handleSearch,
+  newsSearchTool,
+  handleNewsSearch,
+  broadSearchTool,
+  handleBroadSearch,
+} from "./search.js";
 
 const server = new Server(
   {
     name: "octen-mcp",
-    version: "0.2.0",
+    version: "0.3.0",
   },
   {
     capabilities: {
@@ -30,7 +37,7 @@ const server = new Server(
 
 // 1. List available tools — clients call this first to discover what we offer.
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [searchTool, newsSearchTool, extractTool],
+  tools: [searchTool, newsSearchTool, broadSearchTool, extractTool],
 }));
 
 // 2. Dispatch tool calls.
@@ -42,6 +49,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       return await handleSearch(args ?? {});
     case "news_search":
       return await handleNewsSearch(args ?? {});
+    case "broad_search":
+      return await handleBroadSearch(args ?? {});
     case "extract":
       return await handleExtract(args ?? {});
     default:

--- a/src/search.ts
+++ b/src/search.ts
@@ -320,7 +320,7 @@ function formatResult(r: any, idx: number, total: number): string {
   return lines.join("\n");
 }
 
-function formatMeta(meta: any, requestId: string | undefined): string {
+export function formatMeta(meta: any, requestId: string | undefined): string {
   const parts: string[] = [];
   const u = meta?.usage;
   if (u && typeof u === "object") {
@@ -336,6 +336,6 @@ function formatMeta(meta: any, requestId: string | undefined): string {
   return parts.length ? `_${parts.join(" · ")}_` : "";
 }
 
-function errorResult(msg: string): CallToolResult {
+export function errorResult(msg: string): CallToolResult {
   return { isError: true, content: [{ type: "text", text: msg }] };
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -299,6 +299,140 @@ export async function handleNewsSearch(rawArgs: Record<string, unknown>): Promis
   return handleSearch({ ...rest, topic: "news" });
 }
 
+/**
+ * `broad_search` tool — wraps Octen Broad Search (POST /broad-search).
+ *
+ * Decomposes the query into up to `max_queries` related sub-queries, runs them
+ * concurrently, and returns results grouped per sub-query (not deduplicated).
+ * Params are flattened: the same per-result options as `search` plus
+ * `max_queries`; the handler nests the search options under `search_options`
+ * before POSTing.
+ */
+const { timeout: _omitBroadTimeout, ...broadBaseProperties } =
+  (searchTool.inputSchema as any).properties as Record<string, object>;
+const { query: broadQueryProp, ...broadOptionProperties } = broadBaseProperties;
+
+export const broadSearchTool: Tool = {
+  name: "broad_search",
+  description:
+    "Broad multi-angle web search with Octen. Decomposes `query` into up to " +
+    "`max_queries` related sub-queries, searches them concurrently, and returns " +
+    "results grouped per sub-query (not deduplicated) for comprehensive coverage. " +
+    "Use it for research-style questions that benefit from multiple angles; use " +
+    "`search` for a single focused query. Per-sub-query options (count, topic, " +
+    "domain / text filters, time window, highlight / full_content, media) are the " +
+    "same as `search` and apply to every sub-query.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: broadQueryProp,
+      max_queries: {
+        type: "integer",
+        minimum: 1,
+        maximum: 30,
+        default: 5,
+        description: "Upper bound on the number of sub-queries generated (1-30). Default 5.",
+      },
+      ...broadOptionProperties,
+      timeout: {
+        type: "integer",
+        minimum: 1,
+        maximum: 60,
+        description: "Request timeout in seconds (1-60).",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+interface BroadSearchArgs extends SearchArgs {
+  max_queries?: number;
+}
+
+/** Handler — POSTs to Octen Broad Search and reshapes the grouped response. */
+export async function handleBroadSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+  const args = rawArgs as unknown as BroadSearchArgs;
+
+  if (typeof args.query !== "string" || args.query.trim().length === 0) {
+    return errorResult("`query` must be a non-empty string");
+  }
+  if (!API_KEY) {
+    return errorResult(
+      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
+      "and add it to your MCP client config (see README)."
+    );
+  }
+
+  // `timeout` is an HTTP-client concern; `query` and `max_queries` stay at the
+  // top level, everything else is nested under `search_options`.
+  const { timeout, max_queries, query, ...rest } = args;
+  const searchOptions: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(rest)) {
+    if (value !== undefined) searchOptions[key] = value;
+  }
+
+  const body: Record<string, unknown> = { query };
+  if (max_queries !== undefined) body.max_queries = max_queries;
+  if (Object.keys(searchOptions).length > 0) body.search_options = searchOptions;
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${DEFAULT_API_BASE}/broad-search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY,
+      },
+      body: JSON.stringify(body),
+      signal: timeout ? AbortSignal.timeout(timeout * 1000) : undefined,
+    });
+  } catch (e) {
+    const err = e as Error;
+    if (err.name === "TimeoutError") {
+      return errorResult(`Octen Broad Search timed out after ${timeout}s`);
+    }
+    return errorResult(`Network error calling Octen Broad Search: ${err.message}`);
+  }
+
+  let data: any;
+  try {
+    data = await resp.json();
+  } catch {
+    return errorResult(`Octen Broad Search returned non-JSON (HTTP ${resp.status})`);
+  }
+
+  if (typeof data?.code === "number" && data.code !== 0) {
+    return errorResult(
+      `Octen Broad Search: code=${data.code} msg=${data.msg ?? "(no msg)"}` +
+      (data.request_id ? ` request_id=${data.request_id}` : "")
+    );
+  }
+
+  const groups: any[] = data?.data?.search_results ?? [];
+  const queries: string[] = data?.data?.queries ?? [];
+  const meta = data?.meta ?? {};
+
+  if (groups.length === 0) {
+    return { content: [{ type: "text", text: `No results for "${args.query}".` }] };
+  }
+
+  const header = queries.length
+    ? `Decomposed into ${queries.length} sub-quer${queries.length === 1 ? "y" : "ies"}: ${queries.join(" · ")}`
+    : "";
+  const blocks = groups.map((g: any, gi: number) => {
+    const sub = g?.query ?? `sub-query ${gi + 1}`;
+    const results: any[] = Array.isArray(g?.results) ? g.results : [];
+    const inner = results.length
+      ? results.map((r: any, i: number) => formatResult(r, i + 1, results.length)).join("\n\n---\n\n")
+      : "_No results._";
+    return `# Sub-query: ${sub}\n\n${inner}`;
+  });
+  const metaLine = formatMeta(meta, data?.request_id);
+  const text = [header, ...blocks, metaLine].filter(Boolean).join("\n\n---\n\n");
+
+  return { content: [{ type: "text", text }] };
+}
+
 function formatResult(r: any, idx: number, total: number): string {
   const lines: string[] = [`## Result ${idx}/${total}: ${r.title ?? "(untitled)"}`];
   if (r.url) lines.push(r.url);

--- a/src/search.ts
+++ b/src/search.ts
@@ -315,13 +315,17 @@ const { query: broadQueryProp, ...broadOptionProperties } = broadBaseProperties;
 export const broadSearchTool: Tool = {
   name: "broad_search",
   description:
-    "Broad multi-angle web search with Octen. Decomposes `query` into up to " +
-    "`max_queries` related sub-queries, searches them concurrently, and returns " +
-    "results grouped per sub-query (not deduplicated) for comprehensive coverage. " +
-    "Use it for research-style questions that benefit from multiple angles; use " +
-    "`search` for a single focused query. Per-sub-query options (count, topic, " +
-    "domain / text filters, time window, highlight / full_content, media) are the " +
-    "same as `search` and apply to every sub-query.",
+    "Broad multi-angle web search with Octen. Best for questions that span " +
+    "several subtopics where a single `search` only reaches a few: comparisons " +
+    "across many sources (pricing, products, vendors), surveys and deeper " +
+    "research, and any multi-angle question. Pass the user's full question as " +
+    "`query` AS-IS — Octen expands it into related sub-queries and searches them " +
+    "concurrently, returning results grouped per sub-query (not deduplicated). Do " +
+    "NOT pre-split the question or call this repeatedly; raise `max_queries` for " +
+    "broader coverage instead. For a single focused lookup, use `search`. " +
+    "Per-sub-query options (count, topic, domain / text filters, time window, " +
+    "highlight / full_content, media) are the same as `search` and apply to every " +
+    "sub-query.",
   inputSchema: {
     type: "object",
     properties: {
@@ -331,7 +335,9 @@ export const broadSearchTool: Tool = {
         minimum: 1,
         maximum: 30,
         default: 5,
-        description: "Upper bound on the number of sub-queries generated (1-30). Default 5.",
+        description:
+          "Upper bound on the number of sub-queries generated (1-30). Default 5 — " +
+          "raise toward 30 for surveys / deeper research, lower for a tighter search.",
       },
       ...broadOptionProperties,
       timeout: {

--- a/src/videoSearch.ts
+++ b/src/videoSearch.ts
@@ -31,6 +31,7 @@ export const videoSearchTool: Tool = {
     properties: {
       query: {
         type: "string",
+        maxLength: 500,
         description: "Text query describing the videos to find.",
       },
       count: {

--- a/src/videoSearch.ts
+++ b/src/videoSearch.ts
@@ -1,0 +1,182 @@
+/**
+ * `video_search` tool — wraps Octen Video Search API (POST /video-search).
+ *
+ * Invite-only beta. Surfaced to the LLM as a video-search tool: it takes a
+ * text `query` and returns ranked videos (title, source page, cover image,
+ * duration, matching segment, authors, description).
+ *
+ * The underlying API accepts a TEXT-ONLY `inputs` array. We FLATTEN that for
+ * the LLM: a top-level `query` string becomes `[{type:"text", data:query}]`.
+ *
+ * Same envelope (`{code, msg, request_id, data, meta}`) and `x-api-key` auth
+ * as search; `meta` sits at the top level (sibling of `data`).
+ */
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { formatMeta, errorResult } from "./search.js";
+
+const DEFAULT_API_BASE = process.env.OCTEN_API_URL ?? "https://api.octen.ai";
+const API_KEY = process.env.OCTEN_API_KEY;
+
+/** Tool advertisement — clients see this in the list-tools response. */
+export const videoSearchTool: Tool = {
+  name: "video_search",
+  description:
+    "In Beta. Contact us to request beta access. Search the live web for " +
+    "videos with Octen and return ranked results (title, source page, cover " +
+    "image, duration, matching segment, authors, description). Pass a text " +
+    "`query`. Use this when the user wants to find videos, clips, or footage " +
+    "— not for general text web search.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Text query describing the videos to find.",
+      },
+      count: {
+        type: "integer",
+        minimum: 1,
+        maximum: 10,
+        default: 5,
+        description: "Number of results to return (1-10). Default 5.",
+      },
+      time_range: {
+        type: "string",
+        enum: ["day", "week", "month", "year", "d", "w", "m", "y"],
+        description:
+          "Relative time window (e.g. `week`, `month`). Mutually exclusive with " +
+          "`start_time`/`end_time` — if both are given, the absolute range wins.",
+      },
+      start_time: {
+        type: "string",
+        description: "Lower bound for the time window, ISO 8601 (e.g. '2025-01-01T00:00:00Z').",
+      },
+      end_time: {
+        type: "string",
+        description: "Upper bound for the time window, ISO 8601.",
+      },
+      safesearch: {
+        type: "string",
+        enum: ["off", "strict"],
+        default: "strict",
+        description: "Adult-content filter. Default strict.",
+      },
+      timeout: {
+        type: "integer",
+        minimum: 1,
+        maximum: 60,
+        description: "Request timeout in seconds (1-60).",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+interface VideoSearchArgs {
+  query: string;
+  count?: number;
+  time_range?: "day" | "week" | "month" | "year" | "d" | "w" | "m" | "y";
+  start_time?: string;
+  end_time?: string;
+  safesearch?: "off" | "strict";
+  timeout?: number;
+}
+
+/** Handler — POSTs to Octen Video Search and reshapes the response for the LLM. */
+export async function handleVideoSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+  const args = rawArgs as unknown as VideoSearchArgs;
+
+  if (typeof args.query !== "string" || args.query.trim().length === 0) {
+    return errorResult("`query` must be a non-empty string");
+  }
+  if (!API_KEY) {
+    return errorResult(
+      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
+      "and add it to your MCP client config (see README)."
+    );
+  }
+
+  // `timeout` is an HTTP-client concern; `query` is flattened into `inputs` (text only).
+  const { timeout, query, ...payloadArgs } = args;
+
+  const inputs: Array<Record<string, unknown>> = [{ type: "text", data: query }];
+
+  // Drop undefined fields so server defaults apply.
+  const body: Record<string, unknown> = { inputs };
+  for (const [key, value] of Object.entries(payloadArgs)) {
+    if (value !== undefined) body[key] = value;
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${DEFAULT_API_BASE}/video-search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY,
+      },
+      body: JSON.stringify(body),
+      signal: timeout ? AbortSignal.timeout(timeout * 1000) : undefined,
+    });
+  } catch (e) {
+    const err = e as Error;
+    if (err.name === "TimeoutError") {
+      return errorResult(`Octen Video Search timed out after ${timeout}s`);
+    }
+    return errorResult(`Network error calling Octen Video Search: ${err.message}`);
+  }
+
+  // Octen returns the envelope even on errors (code: 401, 429, etc.),
+  // so we read the body regardless of HTTP status.
+  let data: any;
+  try {
+    data = await resp.json();
+  } catch {
+    return errorResult(`Octen Video Search returned non-JSON (HTTP ${resp.status})`);
+  }
+
+  // Envelope-level error: surface code + msg verbatim.
+  if (typeof data?.code === "number" && data.code !== 0) {
+    return errorResult(
+      `Octen Video Search: code=${data.code} msg=${data.msg ?? "(no msg)"}` +
+      (data.request_id ? ` request_id=${data.request_id}` : "")
+    );
+  }
+
+  const results = data?.data?.results ?? [];
+  const meta = data?.meta ?? {};
+  const total = results.length;
+
+  if (total === 0) {
+    return { content: [{ type: "text", text: `No video results for "${args.query}".` }] };
+  }
+
+  const blocks = results.map((r: any, i: number) => formatResult(r, i + 1, total));
+  const metaLine = formatMeta(meta, data?.request_id);
+  const text = [...blocks, metaLine].filter(Boolean).join("\n\n---\n\n");
+
+  return { content: [{ type: "text", text }] };
+}
+
+function formatResult(r: any, idx: number, total: number): string {
+  const lines: string[] = [`## Result ${idx}/${total}: ${r.title ?? "(untitled)"}`];
+  if (r.url) lines.push(r.url);
+  if (r.source_page) lines.push(`**Source page:** ${r.source_page}`);
+  if (r.cover_url) lines.push(`**Cover:** ${r.cover_url}`);
+  if (typeof r.duration_seconds === "number") lines.push(`**Duration:** ${r.duration_seconds}s`);
+  const seg = r.match_segment;
+  if (seg && typeof seg === "object" &&
+      (typeof seg.start_seconds === "number" || typeof seg.end_seconds === "number")) {
+    lines.push(`**Match segment:** ${seg.start_seconds ?? "?"}s–${seg.end_seconds ?? "?"}s`);
+  }
+  if (r.authors) {
+    const authors = Array.isArray(r.authors) ? r.authors.join(", ") : r.authors;
+    lines.push(`**Authors:** ${authors}`);
+  }
+  if (r.time_published) lines.push(`**Published:** ${r.time_published}`);
+  if (r.time_last_crawled) lines.push(`**Last crawled:** ${r.time_last_crawled}`);
+  if (typeof r.description === "string" && r.description.length > 0) {
+    lines.push(`\n### Description\n${r.description}`);
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
Combines broad-search and image/video-search into one PR (supersedes #8 and #9). Bumps to **0.3.0**.

## Summary
- `broad_search` → `POST /broad-search` (multi-angle, grouped per sub-query).
- `image_search` (flattened `query` + optional `image_url`) → `POST /image-search` — **In Beta**.
- `video_search` (text `query`) → `POST /video-search` — **In Beta**.
- All registered in ListTools + dispatch; server version 0.3.0.

## Test plan
- [x] `npm run build`; `tools/list` shows all 6 tools (search, news_search, broad_search, extract, image_search, video_search)
- [x] Live e2e on merged branch: `tools/call` for broad_search / image_search / video_search all return non-error grouped/list output