### PR TITLE
feat(search): add country param to search, news_search and broad_search tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] — 2026-07-16
+
+### Added
+- **`country`** input parameter on `search`, `news_search`, and `broad_search` —
+  ISO 3166-1 alpha-2 country code (e.g. `US`, `JP`) or `auto` (server default)
+  for region-specific results. Sent top-level on `POST /search`; nested under
+  `search_options` on `POST /broad-search`. Omitted from the request when unset
+  so the server default applies.
+- Minimal unit-test suite (`npm test`, Node's built-in `node:test` runner)
+  covering request-body assembly for `search` / `news_search` / `broad_search`.
+
 ## [0.3.1] — 2026-07-06
 
 Aligns the `extract` tool with the current Extract API reference
@@ -103,7 +114,9 @@ Aligns the `extract` tool with the current Extract API reference
 - `OCTEN_API_KEY` env var for authentication.
 - `OCTEN_API_URL` override for staging or self-hosted endpoints.
 
-[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Octen-Team/octen-mcp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Octen-Team/octen-mcp/releases/tag/v0.2.0
 [0.1.5]: https://github.com/Octen-Team/octen-mcp/releases/tag/v0.1.5

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MCP server for **Octen**. Plug it into Claude, Cursor, VS Code, Windsurf, or any
 
 Core capabilities:
 
-- **`search` / `news_search`**: search the live web with domain, text, and time filters.
+- **`search` / `news_search`**: search the live web with domain, text, time, and region (`country`) filters.
 - **`broad_search`**: decompose a query into multiple sub-queries, search them concurrently, and return results grouped per sub-query for broad coverage.
 - **`extract`**: turn one or more URLs into clean, LLM-ready content.
 - **`image_search`** (In Beta — contact us for beta access): search the web for images by text query, optionally with a reference image.
@@ -84,9 +84,9 @@ For clients without a CLI installer, drop the JSON config above into:
 
 | Tool | What it does | Best for |
 |---|---|---|
-| `search` | Search the live web with domain, text, time, and content controls | a single focused web search |
+| `search` | Search the live web with domain, text, time, region (`country`), and content controls | a single focused web search |
 | `news_search` | Same engine as `search`, fixed to news | current events and timely reporting |
-| `broad_search` | Decompose a query into up to `max_queries` sub-queries, search concurrently, return grouped results | research-style, multi-angle coverage |
+| `broad_search` | Decompose a query into up to `max_queries` sub-queries, search concurrently, return grouped results (same per-sub-query options as `search`, incl. `country`) | research-style, multi-angle coverage |
 | `extract` | Fetch 1-20 URLs and return clean content, labels, and optional highlights | summarization, RAG, fact lookup |
 | `image_search` | _In Beta — contact us for beta access._ Search the web for images by text query (optional reference `image_url`) | finding pictures, photos, visual references |
 | `video_search` | _In Beta — contact us for beta access._ Search the web for videos by text query | finding videos, clips, footage |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octen-mcp",
-  "version": "0.2.2",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octen-mcp",
-      "version": "0.2.2",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",
@@ -29,6 +29,8 @@
     "watch": "tsc --watch",
     "dev": "tsc && node dist/index.js",
     "inspect": "npx -y @modelcontextprotocol/inspector node dist/index.js",
+    "pretest": "npm run build",
+    "test": "node --test test/*.test.mjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { videoSearchTool, handleVideoSearch } from "./videoSearch.js";
 const server = new Server(
   {
     name: "octen-mcp",
-    version: "0.3.0",
+    version: "0.3.2",
   },
   {
     capabilities: {

--- a/src/search.ts
+++ b/src/search.ts
@@ -5,8 +5,9 @@
  *  - `topic` (general | news) — switch between broad web and news-focused search
  *  - per-result `highlight` (ranked snippet) OR `full_content` (cleaned page body),
  *    each with a token budget so the model controls how much context it pulls back
- *  - domain / text include-exclude filters and a published/crawled time window
- *    (absolute `start_time`/`end_time` or relative `time_range`)
+ *  - domain / text include-exclude filters, a `country` region filter, and a
+ *    published/crawled time window (absolute `start_time`/`end_time` or
+ *    relative `time_range`)
  *
  * Same envelope (`{code, msg, data, meta}`) and `x-api-key` auth as extract, but
  * note `meta` sits at the TOP level here (sibling of `data`), not under `data`.
@@ -25,7 +26,8 @@ export const searchTool: Tool = {
     "to get a ranked snippet per result, or `full_content` to pull the cleaned " +
     "page body inline (heavier — costs more context). Narrow with domain / text " +
     "include-exclude filters and a time window (published/crawled `start_time`/" +
-    "`end_time`, or a relative `time_range`). Set `include_images` / `include_videos` " +
+    "`end_time`, or a relative `time_range`). Set `country` (ISO 3166-1 alpha-2, " +
+    "e.g. `US`) for region-specific results. Set `include_images` / `include_videos` " +
     "to return media URLs per result.",
   inputSchema: {
     type: "object",
@@ -49,6 +51,13 @@ export const searchTool: Tool = {
         maximum: 100,
         default: 5,
         description: "Number of results to return (1-100). Default 5.",
+      },
+      country: {
+        type: "string",
+        default: "auto",
+        description:
+          "Country code for region-specific results. ISO 3166-1 alpha-2 " +
+          "(e.g. `US`, `JP`), or `auto` to determine automatically. Default auto.",
       },
       include_domains: {
         type: "array",
@@ -178,8 +187,8 @@ export const newsSearchTool: Tool = {
     "Search recent news with Octen and return ranked articles (title, url, " +
     "snippet). This is web search locked to `topic: news` — use it for current " +
     "events, headlines, and timely reporting. Same options as `search` " +
-    "(domain / text filters, time window, highlight / full_content, media) " +
-    "except `topic`, which is fixed to news.",
+    "(country, domain / text filters, time window, highlight / full_content, " +
+    "media) except `topic`, which is fixed to news.",
   inputSchema: {
     type: "object",
     properties: newsProperties,
@@ -201,6 +210,7 @@ interface SearchArgs {
   query: string;
   topic?: "general" | "news";
   count?: number;
+  country?: string;
   include_domains?: string[];
   exclude_domains?: string[];
   include_text?: string[];
@@ -323,9 +333,9 @@ export const broadSearchTool: Tool = {
     "concurrently, returning results grouped per sub-query (not deduplicated). Do " +
     "NOT pre-split the question or call this repeatedly; raise `max_queries` for " +
     "broader coverage instead. For a single focused lookup, use `search`. " +
-    "Per-sub-query options (count, topic, domain / text filters, time window, " +
-    "highlight / full_content, media) are the same as `search` and apply to every " +
-    "sub-query.",
+    "Per-sub-query options (count, topic, country, domain / text filters, time " +
+    "window, highlight / full_content, media) are the same as `search` and apply " +
+    "to every sub-query.",
   inputSchema: {
     type: "object",
     properties: {

--- a/test/search.test.mjs
+++ b/test/search.test.mjs
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for request-body assembly in the search tools (built output).
+ *
+ * Run with `npm test` (builds first, then `node --test test/`). Global `fetch`
+ * is stubbed so no network traffic happens; we assert on the outgoing payload.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// The module reads OCTEN_API_KEY at import time — set it before importing.
+process.env.OCTEN_API_KEY = process.env.OCTEN_API_KEY ?? "test-key";
+
+const { searchTool, newsSearchTool, broadSearchTool, handleSearch, handleNewsSearch, handleBroadSearch } =
+  await import("../dist/search.js");
+
+/** Stub global fetch for one call; returns the captured {url, body}. */
+function captureFetch(responseData = { code: 0, data: { results: [] } }) {
+  const captured = {};
+  globalThis.fetch = async (url, init) => {
+    captured.url = String(url);
+    captured.body = JSON.parse(init.body);
+    return {
+      status: 200,
+      json: async () => responseData,
+    };
+  };
+  return captured;
+}
+
+test("search: schema advertises `country` (string, default auto)", () => {
+  const prop = searchTool.inputSchema.properties.country;
+  assert.ok(prop, "country missing from search inputSchema");
+  assert.equal(prop.type, "string");
+  assert.equal(prop.default, "auto");
+});
+
+test("news_search: schema inherits `country`, drops `topic`", () => {
+  assert.ok(newsSearchTool.inputSchema.properties.country);
+  assert.equal(newsSearchTool.inputSchema.properties.topic, undefined);
+});
+
+test("broad_search: schema inherits `country`", () => {
+  assert.ok(broadSearchTool.inputSchema.properties.country);
+});
+
+test("search: `country` is sent top-level in the /search body", async () => {
+  const captured = captureFetch();
+  await handleSearch({ query: "best local pizza", country: "US", count: 2 });
+  assert.ok(captured.url.endsWith("/search"));
+  assert.equal(captured.body.country, "US");
+  assert.equal(captured.body.count, 2);
+});
+
+test("search: `country` is omitted from the body when unset", async () => {
+  const captured = captureFetch();
+  await handleSearch({ query: "best local pizza" });
+  assert.equal("country" in captured.body, false);
+});
+
+test("news_search: `country` passes through top-level, topic forced to news", async () => {
+  const captured = captureFetch();
+  await handleNewsSearch({ query: "chip news", country: "JP" });
+  assert.equal(captured.body.country, "JP");
+  assert.equal(captured.body.topic, "news");
+});
+
+test("broad_search: `country` is nested under search_options, not top-level", async () => {
+  const captured = captureFetch({ code: 0, data: { search_results: [], queries: [] } });
+  await handleBroadSearch({ query: "ev charging networks", country: "US", count: 2 });
+  assert.ok(captured.url.endsWith("/broad-search"));
+  assert.equal("country" in captured.body, false, "country must not be top-level on /broad-search");
+  assert.equal(captured.body.search_options.country, "US");
+  assert.equal(captured.body.search_options.count, 2);
+});
+
+test("broad_search: `country` (and search_options) omitted when unset", async () => {
+  const captured = captureFetch({ code: 0, data: { search_results: [], queries: [] } });
+  await handleBroadSearch({ query: "ev charging networks" });
+  assert.equal("country" in captured.body, false);
+  assert.equal("search_options" in captured.body, false);
+});


### PR DESCRIPTION
## Summary
- Add optional `country` to the `search`, `news_search`, and `broad_search` tool schemas (ISO 3166-1 alpha-2, e.g. `US`/`JP`, or `auto` — server default; omitted from the API request when unset). `news_search`/`broad_search` inherit via the existing derived-schema chain.
- Payload placement per live-verified contract: top-level on `/search`; inside `search_options` on `/broad-search`.
- Housekeeping shipped with the bump: `src/index.ts` self-reported version was stale at 0.3.0 → now 0.3.2; CHANGELOG compare links reconciled; introduced a minimal `node:test` suite over the built output (repo previously had none) + `npm test` script.
- README tool docs, CHANGELOG `0.3.2`, version bump 0.3.1 → 0.3.2.

## Verification
- Unit tests: 8/8 passed (schema presence on all three tools; top-level vs `search_options` placement; omitted when unset, incl. no empty `search_options`).
- Live e2e over stdio JSON-RPC against the built server: `search` with `country=US` and `broad_search` with `country` set both returned real non-isError results with actual URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)