### PR TITLE
docs: align country description with official ISO 3166 wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] — 2026-07-20
+
+### Changed
+- `country` parameter description aligned with the official wording: "Follow ISO 3166, the International Standard for country codes and codes for their subdivisions".
+
 ## [0.3.2] — 2026-07-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octen-mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octen-mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { videoSearchTool, handleVideoSearch } from "./videoSearch.js";
 const server = new Server(
   {
     name: "octen-mcp",
-    version: "0.3.2",
+    version: "0.3.3",
   },
   {
     capabilities: {

--- a/src/search.ts
+++ b/src/search.ts
@@ -26,7 +26,7 @@ export const searchTool: Tool = {
     "to get a ranked snippet per result, or `full_content` to pull the cleaned " +
     "page body inline (heavier — costs more context). Narrow with domain / text " +
     "include-exclude filters and a time window (published/crawled `start_time`/" +
-    "`end_time`, or a relative `time_range`). Set `country` (ISO 3166-1 alpha-2, " +
+    "`end_time`, or a relative `time_range`). Set `country` (ISO 3166 country code, " +
     "e.g. `US`) for region-specific results. Set `include_images` / `include_videos` " +
     "to return media URLs per result.",
   inputSchema: {
@@ -56,8 +56,9 @@ export const searchTool: Tool = {
         type: "string",
         default: "auto",
         description:
-          "Country code for region-specific results. ISO 3166-1 alpha-2 " +
-          "(e.g. `US`, `JP`), or `auto` to determine automatically. Default auto.",
+          "Follow ISO 3166, the International Standard for country codes and " +
+          "codes for their subdivisions (e.g. `US`, `JP`); `auto` (default) " +
+          "determines it automatically.",
       },
       include_domains: {
         type: "array",


### PR DESCRIPTION
Align the country tool-schema descriptions with the official docs wording: "Follow ISO 3166, the International Standard for country codes and codes for their subdivisions". Version 0.3.3 (incl. serverInfo). Tests: 8/8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)