### PR TITLE
chore: remove country tool parameter (0.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] — 2026-07-24
+
+### Removed
+- `country` parameter removed from the search / news_search / broad_search tool schemas.
+
 ## [0.3.3] — 2026-07-20
 
 ### Changed
@@ -119,7 +124,9 @@ Aligns the `extract` tool with the current Extract API reference
 - `OCTEN_API_KEY` env var for authentication.
 - `OCTEN_API_URL` override for staging or self-hosted endpoints.
 
-[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.3...v0.3.4
+[0.3.3]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Octen-Team/octen-mcp/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MCP server for **Octen**. Plug it into Claude, Cursor, VS Code, Windsurf, or any
 
 Core capabilities:
 
-- **`search` / `news_search`**: search the live web with domain, text, time, and region (`country`) filters.
+- **`search` / `news_search`**: search the live web with domain, text, and time filters.
 - **`broad_search`**: decompose a query into multiple sub-queries, search them concurrently, and return results grouped per sub-query for broad coverage.
 - **`extract`**: turn one or more URLs into clean, LLM-ready content.
 - **`image_search`** (In Beta — contact us for beta access): search the web for images by text query, optionally with a reference image.
@@ -84,9 +84,9 @@ For clients without a CLI installer, drop the JSON config above into:
 
 | Tool | What it does | Best for |
 |---|---|---|
-| `search` | Search the live web with domain, text, time, region (`country`), and content controls | a single focused web search |
+| `search` | Search the live web with domain, text, time, and content controls | a single focused web search |
 | `news_search` | Same engine as `search`, fixed to news | current events and timely reporting |
-| `broad_search` | Decompose a query into up to `max_queries` sub-queries, search concurrently, return grouped results (same per-sub-query options as `search`, incl. `country`) | research-style, multi-angle coverage |
+| `broad_search` | Decompose a query into up to `max_queries` sub-queries, search concurrently, return grouped results (same per-sub-query options as `search`) | research-style, multi-angle coverage |
 | `extract` | Fetch 1-20 URLs and return clean content, labels, and optional highlights | summarization, RAG, fact lookup |
 | `image_search` | _In Beta — contact us for beta access._ Search the web for images by text query (optional reference `image_url`) | finding pictures, photos, visual references |
 | `video_search` | _In Beta — contact us for beta access._ Search the web for videos by text query | finding videos, clips, footage |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octen-mcp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octen-mcp",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { videoSearchTool, handleVideoSearch } from "./videoSearch.js";
 const server = new Server(
   {
     name: "octen-mcp",
-    version: "0.3.3",
+    version: "0.3.4",
   },
   {
     capabilities: {

--- a/src/search.ts
+++ b/src/search.ts
@@ -5,9 +5,8 @@
  *  - `topic` (general | news) — switch between broad web and news-focused search
  *  - per-result `highlight` (ranked snippet) OR `full_content` (cleaned page body),
  *    each with a token budget so the model controls how much context it pulls back
- *  - domain / text include-exclude filters, a `country` region filter, and a
- *    published/crawled time window (absolute `start_time`/`end_time` or
- *    relative `time_range`)
+ *  - domain / text include-exclude filters and a published/crawled time window
+ *    (absolute `start_time`/`end_time` or relative `time_range`)
  *
  * Same envelope (`{code, msg, data, meta}`) and `x-api-key` auth as extract, but
  * note `meta` sits at the TOP level here (sibling of `data`), not under `data`.
@@ -26,8 +25,7 @@ export const searchTool: Tool = {
     "to get a ranked snippet per result, or `full_content` to pull the cleaned " +
     "page body inline (heavier — costs more context). Narrow with domain / text " +
     "include-exclude filters and a time window (published/crawled `start_time`/" +
-    "`end_time`, or a relative `time_range`). Set `country` (ISO 3166 country code, " +
-    "e.g. `US`) for region-specific results. Set `include_images` / `include_videos` " +
+    "`end_time`, or a relative `time_range`). Set `include_images` / `include_videos` " +
     "to return media URLs per result.",
   inputSchema: {
     type: "object",
@@ -51,14 +49,6 @@ export const searchTool: Tool = {
         maximum: 100,
         default: 5,
         description: "Number of results to return (1-100). Default 5.",
-      },
-      country: {
-        type: "string",
-        default: "auto",
-        description:
-          "Follow ISO 3166, the International Standard for country codes and " +
-          "codes for their subdivisions (e.g. `US`, `JP`); `auto` (default) " +
-          "determines it automatically.",
       },
       include_domains: {
         type: "array",
@@ -188,7 +178,7 @@ export const newsSearchTool: Tool = {
     "Search recent news with Octen and return ranked articles (title, url, " +
     "snippet). This is web search locked to `topic: news` — use it for current " +
     "events, headlines, and timely reporting. Same options as `search` " +
-    "(country, domain / text filters, time window, highlight / full_content, " +
+    "(domain / text filters, time window, highlight / full_content, " +
     "media) except `topic`, which is fixed to news.",
   inputSchema: {
     type: "object",
@@ -211,7 +201,6 @@ interface SearchArgs {
   query: string;
   topic?: "general" | "news";
   count?: number;
-  country?: string;
   include_domains?: string[];
   exclude_domains?: string[];
   include_text?: string[];
@@ -334,7 +323,7 @@ export const broadSearchTool: Tool = {
     "concurrently, returning results grouped per sub-query (not deduplicated). Do " +
     "NOT pre-split the question or call this repeatedly; raise `max_queries` for " +
     "broader coverage instead. For a single focused lookup, use `search`. " +
-    "Per-sub-query options (count, topic, country, domain / text filters, time " +
+    "Per-sub-query options (count, topic, domain / text filters, time " +
     "window, highlight / full_content, media) are the same as `search` and apply " +
     "to every sub-query.",
   inputSchema: {

--- a/test/search.test.mjs
+++ b/test/search.test.mjs
@@ -27,55 +27,58 @@ function captureFetch(responseData = { code: 0, data: { results: [] } }) {
   return captured;
 }
 
-test("search: schema advertises `country` (string, default auto)", () => {
-  const prop = searchTool.inputSchema.properties.country;
-  assert.ok(prop, "country missing from search inputSchema");
-  assert.equal(prop.type, "string");
-  assert.equal(prop.default, "auto");
+test("search: schema advertises `query` (required) and `count`", () => {
+  const props = searchTool.inputSchema.properties;
+  assert.ok(props.query, "query missing from search inputSchema");
+  assert.ok(props.count, "count missing from search inputSchema");
+  assert.equal(props.count.default, 5);
+  assert.ok(searchTool.inputSchema.required.includes("query"));
 });
 
-test("news_search: schema inherits `country`, drops `topic`", () => {
-  assert.ok(newsSearchTool.inputSchema.properties.country);
+test("news_search: schema inherits `count`, drops `topic`", () => {
+  assert.ok(newsSearchTool.inputSchema.properties.count);
   assert.equal(newsSearchTool.inputSchema.properties.topic, undefined);
 });
 
-test("broad_search: schema inherits `country`", () => {
-  assert.ok(broadSearchTool.inputSchema.properties.country);
+test("broad_search: schema inherits `count` and adds `max_queries`", () => {
+  assert.ok(broadSearchTool.inputSchema.properties.count);
+  assert.ok(broadSearchTool.inputSchema.properties.max_queries);
 });
 
-test("search: `country` is sent top-level in the /search body", async () => {
+test("search: `query` and `count` are sent top-level in the /search body", async () => {
   const captured = captureFetch();
-  await handleSearch({ query: "best local pizza", country: "US", count: 2 });
+  await handleSearch({ query: "best local pizza", count: 2 });
   assert.ok(captured.url.endsWith("/search"));
-  assert.equal(captured.body.country, "US");
+  assert.equal(captured.body.query, "best local pizza");
   assert.equal(captured.body.count, 2);
 });
 
-test("search: `country` is omitted from the body when unset", async () => {
+test("search: optional `count` is omitted from the body when unset", async () => {
   const captured = captureFetch();
   await handleSearch({ query: "best local pizza" });
-  assert.equal("country" in captured.body, false);
+  assert.equal(captured.body.query, "best local pizza");
+  assert.equal("count" in captured.body, false);
 });
 
-test("news_search: `country` passes through top-level, topic forced to news", async () => {
+test("news_search: options pass through top-level, topic forced to news", async () => {
   const captured = captureFetch();
-  await handleNewsSearch({ query: "chip news", country: "JP" });
-  assert.equal(captured.body.country, "JP");
+  await handleNewsSearch({ query: "chip news", count: 3 });
+  assert.equal(captured.body.count, 3);
   assert.equal(captured.body.topic, "news");
 });
 
-test("broad_search: `country` is nested under search_options, not top-level", async () => {
+test("broad_search: search options are nested under search_options, not top-level", async () => {
   const captured = captureFetch({ code: 0, data: { search_results: [], queries: [] } });
-  await handleBroadSearch({ query: "ev charging networks", country: "US", count: 2 });
+  await handleBroadSearch({ query: "ev charging networks", count: 2, max_queries: 2 });
   assert.ok(captured.url.endsWith("/broad-search"));
-  assert.equal("country" in captured.body, false, "country must not be top-level on /broad-search");
-  assert.equal(captured.body.search_options.country, "US");
+  assert.equal(captured.body.query, "ev charging networks");
+  assert.equal(captured.body.max_queries, 2);
+  assert.equal("count" in captured.body, false, "count must not be top-level on /broad-search");
   assert.equal(captured.body.search_options.count, 2);
 });
 
-test("broad_search: `country` (and search_options) omitted when unset", async () => {
+test("broad_search: search_options omitted when no per-sub-query options set", async () => {
   const captured = captureFetch({ code: 0, data: { search_results: [], queries: [] } });
   await handleBroadSearch({ query: "ev charging networks" });
-  assert.equal("country" in captured.body, false);
   assert.equal("search_options" in captured.body, false);
 });


### PR DESCRIPTION
Removes `country` from the `search`/`news_search`/`broad_search` tool schemas entirely — API-side the field is being pulled back.

## Verification
- `grep -rniI country src/ test/ README.md` → zero hits.
- Tests: 8/8 passed (country tests replaced with equivalent non-country coverage); build clean.
- Built schema: search/news/broad all report `country=false`.
- Live e2e (stdio): 6 tools intact, none advertise country; search + broad_search work without country.

🤖 Generated with [Claude Code](https://claude.com/claude-code)