### PR TITLE
feat: add language filter to search tools (ISO 639-1) (0.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] — 2026-07-27
+
+### Added
+- `language` parameter (ISO 639-1 codes) for language filtering on the search / news_search / broad_search tools.
+
 ## [0.3.4] — 2026-07-24
 
 ### Removed
@@ -124,7 +129,8 @@ Aligns the `extract` tool with the current Extract API reference
 - `OCTEN_API_KEY` env var for authentication.
 - `OCTEN_API_URL` override for staging or self-hosted endpoints.
 
-[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.5...HEAD
+[0.3.5]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.1...v0.3.2

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MCP server for **Octen**. Plug it into Claude, Cursor, VS Code, Windsurf, or any
 
 Core capabilities:
 
-- **`search` / `news_search`**: search the live web with domain, text, and time filters.
+- **`search` / `news_search`**: search the live web with domain, text, language, and time filters.
 - **`broad_search`**: decompose a query into multiple sub-queries, search them concurrently, and return results grouped per sub-query for broad coverage.
 - **`extract`**: turn one or more URLs into clean, LLM-ready content.
 - **`image_search`** (In Beta — contact us for beta access): search the web for images by text query, optionally with a reference image.
@@ -84,9 +84,9 @@ For clients without a CLI installer, drop the JSON config above into:
 
 | Tool | What it does | Best for |
 |---|---|---|
-| `search` | Search the live web with domain, text, time, and content controls | a single focused web search |
+| `search` | Search the live web with domain, text, language (ISO 639-1), time, and content controls | a single focused web search |
 | `news_search` | Same engine as `search`, fixed to news | current events and timely reporting |
-| `broad_search` | Decompose a query into up to `max_queries` sub-queries, search concurrently, return grouped results (same per-sub-query options as `search`) | research-style, multi-angle coverage |
+| `broad_search` | Decompose a query into up to `max_queries` sub-queries, search concurrently, return grouped results (same per-sub-query options as `search`, including the `language` filter) | research-style, multi-angle coverage |
 | `extract` | Fetch 1-20 URLs and return clean content, labels, and optional highlights | summarization, RAG, fact lookup |
 | `image_search` | _In Beta — contact us for beta access._ Search the web for images by text query (optional reference `image_url`) | finding pictures, photos, visual references |
 | `video_search` | _In Beta — contact us for beta access._ Search the web for videos by text query | finding videos, clips, footage |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octen-mcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octen-mcp",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { videoSearchTool, handleVideoSearch } from "./videoSearch.js";
 const server = new Server(
   {
     name: "octen-mcp",
-    version: "0.3.4",
+    version: "0.3.5",
   },
   {
     capabilities: {

--- a/src/search.ts
+++ b/src/search.ts
@@ -5,7 +5,8 @@
  *  - `topic` (general | news) — switch between broad web and news-focused search
  *  - per-result `highlight` (ranked snippet) OR `full_content` (cleaned page body),
  *    each with a token budget so the model controls how much context it pulls back
- *  - domain / text include-exclude filters and a published/crawled time window
+ *  - domain / text include-exclude filters, a `language` filter (ISO 639-1
+ *    codes), and a published/crawled time window
  *    (absolute `start_time`/`end_time` or relative `time_range`)
  *
  * Same envelope (`{code, msg, data, meta}`) and `x-api-key` auth as extract, but
@@ -24,9 +25,9 @@ export const searchTool: Tool = {
     "snippet). Set `topic` to `news` for news-focused results. Pass `highlight` " +
     "to get a ranked snippet per result, or `full_content` to pull the cleaned " +
     "page body inline (heavier — costs more context). Narrow with domain / text " +
-    "include-exclude filters and a time window (published/crawled `start_time`/" +
-    "`end_time`, or a relative `time_range`). Set `include_images` / `include_videos` " +
-    "to return media URLs per result.",
+    "include-exclude filters, a `language` filter (ISO 639-1 codes), and a time " +
+    "window (published/crawled `start_time`/`end_time`, or a relative `time_range`). " +
+    "Set `include_images` / `include_videos` to return media URLs per result.",
   inputSchema: {
     type: "object",
     properties: {
@@ -109,6 +110,15 @@ export const searchTool: Tool = {
         default: "strict",
         description: "Adult-content filter. Default strict.",
       },
+      language: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: ["ar", "de", "en", "es", "fr", "hi", "id", "it", "ja", "ko", "nl", "pl", "pt", "ru", "th", "tr", "vi", "zh"],
+        },
+        default: [],
+        description: "Languages to filter results by, as ISO 639-1 codes. Empty = no filter.",
+      },
       highlight: {
         type: "object",
         description:
@@ -178,7 +188,7 @@ export const newsSearchTool: Tool = {
     "Search recent news with Octen and return ranked articles (title, url, " +
     "snippet). This is web search locked to `topic: news` — use it for current " +
     "events, headlines, and timely reporting. Same options as `search` " +
-    "(domain / text filters, time window, highlight / full_content, " +
+    "(domain / text filters, `language` filter, time window, highlight / full_content, " +
     "media) except `topic`, which is fixed to news.",
   inputSchema: {
     type: "object",
@@ -211,6 +221,7 @@ interface SearchArgs {
   end_time?: string;
   format?: "text" | "markdown";
   safesearch?: "off" | "strict";
+  language?: string[];
   highlight?: HighlightOptions;
   full_content?: FullContentOptions;
   include_images?: boolean;
@@ -323,7 +334,7 @@ export const broadSearchTool: Tool = {
     "concurrently, returning results grouped per sub-query (not deduplicated). Do " +
     "NOT pre-split the question or call this repeatedly; raise `max_queries` for " +
     "broader coverage instead. For a single focused lookup, use `search`. " +
-    "Per-sub-query options (count, topic, domain / text filters, time " +
+    "Per-sub-query options (count, topic, `language` filter, domain / text filters, time " +
     "window, highlight / full_content, media) are the same as `search` and apply " +
     "to every sub-query.",
   inputSchema: {

--- a/test/search.test.mjs
+++ b/test/search.test.mjs
@@ -45,6 +45,31 @@ test("broad_search: schema inherits `count` and adds `max_queries`", () => {
   assert.ok(broadSearchTool.inputSchema.properties.max_queries);
 });
 
+const LANGUAGE_ENUM = ["ar", "de", "en", "es", "fr", "hi", "id", "it", "ja", "ko", "nl", "pl", "pt", "ru", "th", "tr", "vi", "zh"];
+
+test("search: schema advertises `language` as an enum array (ISO 639-1)", () => {
+  const lang = searchTool.inputSchema.properties.language;
+  assert.ok(lang, "language missing from search inputSchema");
+  assert.equal(lang.type, "array");
+  assert.equal(lang.items.type, "string");
+  assert.deepEqual(lang.items.enum, LANGUAGE_ENUM);
+  assert.deepEqual(lang.default, []);
+});
+
+test("news_search: schema inherits `language`", () => {
+  const lang = newsSearchTool.inputSchema.properties.language;
+  assert.ok(lang, "language missing from news_search inputSchema");
+  assert.equal(lang.type, "array");
+  assert.deepEqual(lang.items.enum, LANGUAGE_ENUM);
+});
+
+test("broad_search: schema inherits `language`", () => {
+  const lang = broadSearchTool.inputSchema.properties.language;
+  assert.ok(lang, "language missing from broad_search inputSchema");
+  assert.equal(lang.type, "array");
+  assert.deepEqual(lang.items.enum, LANGUAGE_ENUM);
+});
+
 test("search: `query` and `count` are sent top-level in the /search body", async () => {
   const captured = captureFetch();
   await handleSearch({ query: "best local pizza", count: 2 });
@@ -58,6 +83,38 @@ test("search: optional `count` is omitted from the body when unset", async () =>
   await handleSearch({ query: "best local pizza" });
   assert.equal(captured.body.query, "best local pizza");
   assert.equal("count" in captured.body, false);
+});
+
+test("search: `language` lands top-level in the /search body when set", async () => {
+  const captured = captureFetch();
+  await handleSearch({ query: "climate change", language: ["ja", "en"] });
+  assert.deepEqual(captured.body.language, ["ja", "en"]);
+});
+
+test("search: `language` omitted from the body when unset", async () => {
+  const captured = captureFetch();
+  await handleSearch({ query: "climate change" });
+  assert.equal("language" in captured.body, false);
+});
+
+test("news_search: `language` passes through top-level", async () => {
+  const captured = captureFetch();
+  await handleNewsSearch({ query: "chip news", language: ["de"] });
+  assert.deepEqual(captured.body.language, ["de"]);
+  assert.equal(captured.body.topic, "news");
+});
+
+test("broad_search: `language` nests under search_options, never top-level", async () => {
+  const captured = captureFetch({ code: 0, data: { search_results: [], queries: [] } });
+  await handleBroadSearch({ query: "ai news", language: ["en"], max_queries: 2 });
+  assert.equal("language" in captured.body, false, "language must not be top-level on /broad-search");
+  assert.deepEqual(captured.body.search_options.language, ["en"]);
+});
+
+test("broad_search: `language` absent from search_options when unset", async () => {
+  const captured = captureFetch({ code: 0, data: { search_results: [], queries: [] } });
+  await handleBroadSearch({ query: "ai news", count: 2 });
+  assert.equal("language" in captured.body.search_options, false);
 });
 
 test("news_search: options pass through top-level, topic forced to news", async () => {


### PR DESCRIPTION
Adds `language` — an array of ISO 639-1 codes — to the `search`/`news_search`/`broad_search` tool schemas (declared with the 18-value enum to guide the model). Top-level on `/search`, nested in `search_options` on broad_search; handlers route it automatically.

## Verification
- 16 tests pass (+8); build clean.
- Built schema advertises the enum array on all three tools.
- Live (stdio): `language:["ja"]` → Japanese `.jp` results; broad nests in search_options; invalid `["xx"]` → isError with server message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)