### PR TITLE
docs(tools): rewrite tool descriptions for discovery & routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] — 2026-07-30
+
+### Changed
+- Tool **descriptions** rewritten for discovery & routing in deferred-loading
+  clients (no behavior/schema/param change):
+  - Every tool now opens with a generic, retrieval-friendly first sentence
+    (no brand name or internal jargon up front) and carries a `keywords:` line —
+    `image_search` / `video_search` no longer open with "In Beta.".
+  - `broad_search` gained an explicit **COST** signal, four concrete negative
+    examples (single fact → `search`; don't re-run; known URL → `extract`;
+    A-vs-B → two `search` calls), a `max_queries` problem-type → number mapping,
+    pronoun-resolution guidance, and a `broad_search + topic=news` boundary.
+  - `search` gained symmetric guidance pointing multi-subtopic questions to
+    `broad_search`; sibling cross-references added across `search` / `broad_search`
+    / `extract`.
+- README: optional `alwaysLoad` ("keep the tools always on") section for clients
+  with MCP tool search enabled.
+
 ## [0.3.6] — 2026-07-28
 
 ### Added
@@ -137,7 +155,8 @@ Aligns the `extract` tool with the current Extract API reference
 - `OCTEN_API_KEY` env var for authentication.
 - `OCTEN_API_URL` override for staging or self-hosted endpoints.
 
-[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.6...HEAD
+[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.7...HEAD
+[0.3.7]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.3...v0.3.4

--- a/README.md
+++ b/README.md
@@ -96,6 +96,32 @@ Reference docs:
 - Search: [docs.octen.ai/api-reference/search](https://docs.octen.ai/api-reference/search)
 - Extract: [docs.octen.ai/api-reference/extract](https://docs.octen.ai/api-reference/extract)
 
+### Keep the tools always on (optional)
+
+In clients with **MCP tool search** enabled (the Claude Code default), tools are
+*deferred* — the model runs a `ToolSearch` step to load them on demand. If you'd
+rather have the Octen tools resident from the first turn (no discovery step), set
+`alwaysLoad` on the server in your `.mcp.json` (Claude Code v2.1.121+):
+
+```jsonc
+{
+  "mcpServers": {
+    "octen": {
+      "command": "npx",
+      "args": ["-y", "octen-mcp"],
+      "env": { "OCTEN_API_KEY": "your-key-here" },
+      "alwaysLoad": true
+    }
+  }
+}
+```
+
+Each always-loaded tool uses context on every turn, and `alwaysLoad` blocks startup
+until the server connects (capped at the ~5s connect timeout), so reserve it for tools
+you hit constantly. To keep the cost down, mark just the highest-traffic tools — e.g.
+`search` and `broad_search` — with `"anthropic/alwaysLoad": true` in each tool's `_meta`,
+leaving the rest deferred.
+
 ## Why agents like this
 
 Most extract tools stop at "here is the page body." Octen helps one step earlier:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -17,14 +17,11 @@ const API_KEY = process.env.OCTEN_API_KEY;
 export const extractTool: Tool = {
   name: "extract",
   description:
-    "Fetch one or more URLs and return LLM-ready content from Octen. " +
-    "By default (no `query`) it returns each page's full content — this is " +
-    "what you want in almost all cases. Only pass `query` when the user " +
-    "explicitly asks to fetch relevance-ranked snippets for a specific topic; " +
-    "doing so returns highlights INSTEAD of the full body, so the content " +
-    "will be partial. Every result also includes a `category` (topical) and " +
-    "`page_structure` (typology) classification, unique to Octen. Bare hosts " +
-    "like 'octen.ai' are auto-normalized to https. Cached when fresh.",
+    `Read one or more web pages by URL and return clean, LLM-ready content (markdown or text). By default (no \`query\`) it returns each page's full content — this is what you want in almost all cases. Only pass \`query\` when the user explicitly asks to fetch relevance-ranked snippets for a specific topic; doing so returns highlights INSTEAD of the full body, so the content will be partial. Every result also includes a \`category\` (topical) and \`page_structure\` (typology) classification. Bare hosts like 'octen.ai' are auto-normalized to https. Cached when fresh.
+
+Use this when you already have the URL(s). To find pages first, use \`search\` or \`broad_search\`.
+
+keywords: read page, fetch url, scrape, page content, article text, parse webpage, extract, read article, url content, open link`,
   inputSchema: {
     type: "object",
     properties: {

--- a/src/imageSearch.ts
+++ b/src/imageSearch.ts
@@ -23,14 +23,9 @@ const API_KEY = process.env.OCTEN_API_KEY;
 export const imageSearchTool: Tool = {
   name: "image_search",
   description:
-    "In Beta. Contact us to request beta access. Search the live web for " +
-    "images with Octen and return ranked results (title, source page, " +
-    "dimensions, thumbnail, description, summary). Pass a text `query`, and " +
-    "optionally an `image_url` to search by reference image. Set `topic` to " +
-    "`design` for UI design references — each result then carries a structured " +
-    "style `summary` and an `html_snippet` for building/restyling frontends. " +
-    "Use this when the user wants to find pictures, photos, diagrams, or visual " +
-    "references — not for general text web search.",
+    `Find images on the web by text query, and optionally by a reference image — returns ranked results (title, source page, dimensions, thumbnail, description, summary). In Beta; contact us to request beta access. Pass a text \`query\`, and optionally an \`image_url\` to search by reference image. Set \`topic\` to \`design\` for UI design references — each result then carries a structured style \`summary\` and an \`html_snippet\` for building/restyling frontends. Use this when the user wants pictures, photos, diagrams, screenshots, or visual references — not for general text web search.
+
+keywords: find images, image search, photos, pictures, screenshots, visual reference, diagram, icon, illustration, UI design, reference image`,
   inputSchema: {
     type: "object",
     properties: {

--- a/src/search.ts
+++ b/src/search.ts
@@ -21,13 +21,11 @@ const API_KEY = process.env.OCTEN_API_KEY;
 export const searchTool: Tool = {
   name: "search",
   description:
-    "Search the live web with Octen and return ranked results (title, url, " +
-    "snippet). Set `topic` to `news` for news-focused results. Pass `highlight` " +
-    "to get a ranked snippet per result, or `full_content` to pull the cleaned " +
-    "page body inline (heavier — costs more context). Narrow with domain / text " +
-    "include-exclude filters, a `language` filter (ISO 639-1 codes), and a time " +
-    "window (published/crawled `start_time`/`end_time`, or a relative `time_range`). " +
-    "Set `include_images` / `include_videos` to return media URLs per result.",
+    `Search the live web and return ranked results (title, url, snippet) — fast, fresh, real-time web search for one focused lookup. Set \`topic\` to \`news\` for news-focused results. Pass \`highlight\` to get a ranked snippet per result, or \`full_content\` to pull the cleaned page body inline (heavier — costs more context). Narrow with domain / text include-exclude filters, a \`language\` filter (ISO 639-1 codes), and a time window (published/crawled \`start_time\`/\`end_time\`, or a relative \`time_range\`). Set \`include_images\` / \`include_videos\` to return media URLs per result.
+
+USE FOR a single focused lookup: one fact, one entity, one document. If the question spans several independent subtopics, load and use \`broad_search\` instead — a sequence of search calls is slower and gives worse coverage than one fan-out. To read a page you already have the URL for, use \`extract\`.
+
+keywords: web search, search the web, look up, find, check, fact, current information, latest, news, source, url, real-time`,
   inputSchema: {
     type: "object",
     properties: {
@@ -185,11 +183,11 @@ const { topic: _omitTopic, ...newsProperties } =
 export const newsSearchTool: Tool = {
   name: "news_search",
   description:
-    "Search recent news with Octen and return ranked articles (title, url, " +
-    "snippet). This is web search locked to `topic: news` — use it for current " +
-    "events, headlines, and timely reporting. Same options as `search` " +
-    "(domain / text filters, `language` filter, time window, highlight / full_content, " +
-    "media) except `topic`, which is fixed to news.",
+    `Search recent news and return ranked articles (title, url, snippet) — current events, headlines, timely reporting. This is \`search\` locked to \`topic: news\`; same options as \`search\` (domain / text filters, \`language\` filter, time window, highlight / full_content, media) except \`topic\`, which is fixed to news.
+
+For a single news lookup this is the right tool. For a multi-angle news question ("what shipped across the industry this month", "how are different outlets covering X"), use \`broad_search\` with topic=news instead of looping news_search.
+
+keywords: news search, latest news, headlines, current events, breaking news, recent, today, this week, press coverage`,
   inputSchema: {
     type: "object",
     properties: newsProperties,
@@ -326,17 +324,32 @@ const { query: broadQueryProp, ...broadOptionProperties } = broadBaseProperties;
 export const broadSearchTool: Tool = {
   name: "broad_search",
   description:
-    "Broad multi-angle web search with Octen. Best for questions that span " +
-    "several subtopics where a single `search` only reaches a few: comparisons " +
-    "across many sources (pricing, products, vendors), surveys and deeper " +
-    "research, and any multi-angle question. Pass the user's full question as " +
-    "`query` AS-IS — Octen expands it into related sub-queries and searches them " +
-    "concurrently, returning results grouped per sub-query (not deduplicated). Do " +
-    "NOT pre-split the question or call this repeatedly; raise `max_queries` for " +
-    "broader coverage instead. For a single focused lookup, use `search`. " +
-    "Per-sub-query options (count, topic, `language` filter, domain / text filters, time " +
-    "window, highlight / full_content, media) are the same as `search` and apply " +
-    "to every sub-query.",
+    `Search the web across many angles in one call — for comparisons, research, surveys, and questions with several distinct parts. Expands your question into multiple sub-queries and runs them concurrently.
+
+USE WHEN the question has multiple distinct parts or entities that one search cannot cover:
+  - comparing vendors / products / pricing across many sources
+  - literature reviews, market or landscape surveys
+  - open-ended "what are the options for X" / "how do people solve Y"
+  - a question that clearly decomposes into 3+ independent sub-questions
+  - multi-angle questions about recent events ("what shipped across the industry this month") — set topic=news, do NOT loop news_search
+
+DO NOT USE for:
+  - a single fact, entity, or document → use \`search\`
+  - re-running a disappointing search → do NOT call broad_search twice; follow up with a targeted \`search\` or \`extract\` on the specific gaps
+  - reading a page you already have the URL for → use \`extract\`
+  - a straight A-vs-B comparison of two known entities → two targeted \`search\` calls are cheaper and more controllable
+
+COST: fans out into \`max_queries\` concurrent searches — roughly Nx the cost and notably higher latency than a single \`search\`. When in doubt, prefer \`search\`.
+
+QUERY: pass one natural-language question (max 500 chars). Resolve pronouns and references from the conversation first — "how does it compare to the other one" is a useless query. Do NOT pre-split into sub-queries; that is this tool's job. For broader coverage raise \`max_queries\` rather than calling repeatedly. Per-sub-query options (count, topic, \`language\` filter, domain / text filters, time window, highlight / full_content, media) match \`search\` and apply to every sub-query.
+
+RESULTS are grouped per sub-query and NOT deduplicated — the same URL may appear under several sub-queries.
+
+max_queries: 3-5 focused comparison (2-3 entities) | 5-10 multi-facet research | 10-20 landscape scan | 20-30 exhaustive survey
+
+For a single focused lookup use \`search\`; to read a specific page use \`extract\`.
+
+keywords: web search, search the web, look up, find information, research, compare, comparison, versus, alternatives, options, landscape, survey, market research, pricing, latest, current information, multi-part question`,
   inputSchema: {
     type: "object",
     properties: {

--- a/src/videoSearch.ts
+++ b/src/videoSearch.ts
@@ -21,11 +21,9 @@ const API_KEY = process.env.OCTEN_API_KEY;
 export const videoSearchTool: Tool = {
   name: "video_search",
   description:
-    "In Beta. Contact us to request beta access. Search the live web for " +
-    "videos with Octen and return ranked results (title, source page, cover " +
-    "image, duration, matching segment, authors, description). Pass a text " +
-    "`query`. Use this when the user wants to find videos, clips, or footage " +
-    "— not for general text web search.",
+    `Find videos on the web by text query — returns ranked results (title, source page, cover image, duration, matching segment, authors, description). In Beta; contact us to request beta access. Pass a text \`query\`. Use this when the user wants to find videos, clips, footage, tutorials, or a specific moment within a video — not for general text web search.
+
+keywords: find videos, video search, clips, footage, youtube, tutorial video, watch, movie, video clip`,
   inputSchema: {
     type: "object",
     properties: {


### PR DESCRIPTION
## What & why

Optimizes the Octen MCP **tool descriptions** for discovery and routing in
**deferred-loading** clients (Claude Code / Claude.ai), where a tool's full
description isn't in context until the model runs a `ToolSearch` step — only the
**first sentence** enters the retrieval index, and there was no cost signal to stop
`broad_search` from over-triggering.

**Descriptions + README only — no API / schema / param / return changes.**
`npm run build` + `npm test` (16/16) pass.

## Changes

**All six tools**
- First sentence rewritten to lead with generic, retrieval-friendly search verbs
  (no brand name / internal jargon / "In Beta." up front).
- Added a `keywords:` line for literal intent-term recall.
- Sibling cross-references across `search` / `broad_search` / `extract`.

**`broad_search`** (the routing centerpiece)
- Explicit **COST** signal ("~Nx cost + latency; when in doubt prefer `search`").
- Four concrete negative examples (single fact → `search`; don't re-run; known URL
  → `extract`; A-vs-B → two `search` calls).
- `max_queries` problem-type → number mapping (3-5 / 5-10 / 10-20 / 20-30).
- Pronoun/QUERY-resolution guidance; `broad_search + topic:news` boundary.

**`search`** — symmetric guidance pointing multi-subtopic questions to `broad_search`.

**README** — optional `alwaysLoad` ("keep the tools always on") section, so users on
clients with MCP tool search can make the Octen tools resident from turn 1.

## Validation

Lightweight blind A/B on tricky routing (n=1/query — a directional check, not a full
statistical harness): old descriptions **4/6** vs new **6/6** gold routing. The two
fixes were exactly A-vs-B over-triggering `broad_search` and multi-angle-news routing.

## Companion

Pairs with the `octen-skills` PR adding the `octen-web-search` router/loader skill,
which holds the canonical routing rules (this PR's descriptions carry a compact echo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
