### PR TITLE
fix(http): self-contained fetch — every call fails on Node 26+ (undici 8 rejects the v6 dispatcher) [0.4.2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['18', '20', '22']
+        # 24 and 26 are load-bearing: they embed undici 7/8, whose dispatch
+        # handler protocol rejected our packaged v6 dispatcher in 0.4.1
+        # (UND_ERR_INVALID_ARG on every call, from Node 26). The real-socket
+        # tests only exercise that coupling on a host that actually embeds a
+        # newer undici.
+        node: ['18', '20', '22', '24', '26']
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,7 +342,8 @@ Aligns the `extract` tool with the current Extract API reference
 - `OCTEN_API_KEY` env var for authentication.
 - `OCTEN_API_URL` override for staging or self-hosted endpoints.
 
-[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/Octen-Team/octen-mcp/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/Octen-Team/octen-mcp/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/Octen-Team/octen-mcp/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.7...v0.4.0
 [0.3.7]: https://github.com/Octen-Team/octen-mcp/compare/v0.3.6...v0.3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] — 2026-08-19
+
+### Fixed
+- **Every call failed on Node 26+ (`code=UND_ERR_INVALID_ARG cause=invalid
+  onError method`).** Since 0.4.0 the server built its tuned connection agent
+  from the packaged undici 6 and handed it as `dispatcher` to the host's
+  global `fetch` — coupling two undici versions across the dispatch-handler
+  protocol. undici 8, which Node embeds from 26, removed the legacy handler
+  compatibility that v7 still carried, so the host's fetch rejects the v6
+  dispatcher at validation before a single byte is sent: 100% of tool calls
+  fail on such hosts. 0.4.1 and below need Node <= 24; from 0.4.2 all
+  supported Node versions (>= 18.17) work.
+
+  The fix makes the HTTP stack self-contained — `fetch` and the dispatcher
+  both come from the packaged undici, so the host's embedded undici version
+  is out of the picture entirely, for this incompatibility and for future
+  protocol changes alike. Requests now also pin `accept-encoding` to exactly
+  what the packaged undici can decode (`gzip, deflate, br`) instead of
+  inheriting a scheme- and version-dependent default. CI runs the suite on
+  Node 18/20/22/24/26; a real-socket regression test drives the built server
+  through the packaged stack on the host's own Node, and a lint-style guard
+  keeps global `fetch` / `Response` / `Headers` / `Request` usage out of
+  `src/`.
+
 ## [0.4.1] — 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Clean highlights, optional `full_content`, and page labels keep model context re
 
 You need an `OCTEN_API_KEY` from [octen.ai](https://octen.ai).
 
+> **Node compatibility:** 0.4.2 and later run on every supported Node (>= 18.17),
+> including Node 26+. Versions 0.4.1 and below fail every call on hosts whose
+> embedded undici is v8+ (Node 26 and later) with
+> `Network error … code=UND_ERR_INVALID_ARG cause=invalid onError method` —
+> if you see that error, upgrade the package (or run on Node <= 24).
+
 [![Install in VS Code](https://img.shields.io/badge/Install%20in-VS%20Code-007ACC?logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=octen&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22Octen%20API%20Key%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22octen-mcp%22%5D%2C%22env%22%3A%7B%22OCTEN_API_KEY%22%3A%22%24%7Binput%3AapiKey%7D%22%7D%7D)
 [![Install in VS Code Insiders](https://img.shields.io/badge/Install%20in-VS%20Code%20Insiders-24bfa5?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=octen&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22Octen%20API%20Key%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22octen-mcp%22%5D%2C%22env%22%3A%7B%22OCTEN_API_KEY%22%3A%22%24%7Binput%3AapiKey%7D%22%7D%7D&quality=insiders)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "octen-mcp",
-  "version": "0.3.8",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octen-mcp",
-      "version": "0.3.8",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
-        "undici": "^6.21.0"
+        "undici": "^6.28.0"
       },
       "bin": {
         "octen-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen \u2014 web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
-    "undici": "^6.21.0"
+    "undici": "^6.28.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/http.ts
+++ b/src/http.ts
@@ -25,8 +25,19 @@
  * with a bare `TypeError: fetch failed`; the actual reason (ECONNRESET,
  * UND_ERR_CONNECT_TIMEOUT, ENOTFOUND, …) only exists on `err.cause.code`, and
  * dropping it is what made support tickets undiagnosable.
+ *
+ * The `fetch` itself must come from the same packaged undici as the
+ * dispatcher, never from the host's global. The global fetch is backed by
+ * whatever undici the running Node embeds, and handing it a dispatcher built
+ * from ours couples two undici versions across their dispatch-handler
+ * protocol. undici 8 (embedded from Node 26) removed the legacy handler
+ * compatibility that v7 still carried, so a v6 dispatcher is rejected at
+ * validation — `InvalidArgumentError: invalid onError method` — before any
+ * bytes are sent, failing 100% of calls on those hosts (0.4.1 in the field).
+ * Same-origin fetch + dispatcher makes the HTTP stack self-contained and
+ * immune to whatever the host Node embeds.
  */
-import { Agent, EnvHttpProxyAgent, type Dispatcher } from "undici";
+import { fetch as undiciFetch, Agent, EnvHttpProxyAgent, type Dispatcher } from "undici";
 import { randomUUID } from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
 
@@ -237,6 +248,19 @@ function buildDispatcher(): Dispatcher {
 
 const dispatcher: Dispatcher = buildDispatcher();
 
+/**
+ * Test seam only. The suite scripts outcomes (a scripted ECONNRESET, a
+ * TimeoutError, a canned envelope) that MockAgent cannot express while the
+ * assertions still need the raw `init` — signal identity across the retry,
+ * the dispatcher being attached. Production code must never call this;
+ * calling it with no argument restores the packaged fetch.
+ */
+let fetchImpl: typeof undiciFetch = undiciFetch;
+
+export function _setFetchForTests(f?: typeof undiciFetch): void {
+  fetchImpl = f ?? undiciFetch;
+}
+
 debug(
   `dispatcher=${proxyConfigured ? "EnvHttpProxyAgent" : "Agent"} ` +
   `keepAlive=${agentOptions.keepAliveTimeout}ms connect=${agentOptions.connectTimeout}ms ` +
@@ -403,19 +427,26 @@ async function postJsonInner(opts: PostJsonOptions): Promise<Response> {
   for (let attempt = 1; attempt <= 2; attempt++) {
     const started = Date.now();
     try {
-      const resp = await fetch(`${API_BASE}${path}`, {
+      // The cast bridges a types-only gap: undici 6's bundled `Response` type
+      // predates `bytes()`, which the runtime object has (verified on 6.28.0).
+      // Keeping the global `Response` as this module's currency means callers
+      // and `bodyReadFailure` need no undici types in their signatures.
+      const resp = (await fetchImpl(`${API_BASE}${path}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "x-api-key": apiKey,
           "x-request-id": requestId,
+          // Pinned to exactly what the packaged undici can decode. Left to a
+          // default it varies by scheme (no `br` over plain http) and by
+          // whichever undici is doing the fetching; an origin that honours an
+          // encoding we cannot decode turns every response into garbage.
+          "accept-encoding": "gzip, deflate, br",
         },
         body: payload,
         signal: deadline,
-        // @ts-expect-error — `dispatcher` is an undici extension to RequestInit
-        // that Node honours but the DOM `fetch` types do not declare.
         dispatcher,
-      });
+      })) as unknown as Response;
       if (DEBUG) {
         debug(
           `${path} attempt=${attempt} status=${resp.status} ` +

--- a/test/http.test.mjs
+++ b/test/http.test.mjs
@@ -5,7 +5,10 @@
  * the caller passed `timeout`, reported `err.message` ("fetch failed") while
  * discarding `err.cause`, never retried, and sent no correlation id.
  *
- * Global `fetch` is stubbed, so no network traffic happens.
+ * The HTTP layer's fetch is stubbed through its test seam, so no network
+ * traffic happens. Stubbing `globalThis.fetch` would be a no-op: since the
+ * undici-8 host incompatibility fix, the module fetches through the packaged
+ * undici, never through the global.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -14,6 +17,7 @@ process.env.OCTEN_API_KEY = process.env.OCTEN_API_KEY ?? "test-key";
 
 const { handleSearch, handleBroadSearch, broadSearchTool } = await import("../dist/search.js");
 const { handleExtract } = await import("../dist/extract.js");
+const { _setFetchForTests } = await import("../dist/http.js");
 
 const OK_BODY = { code: 0, data: { results: [] } };
 
@@ -21,14 +25,14 @@ const OK_BODY = { code: 0, data: { results: [] } };
 function scriptFetch(outcomes) {
   const attempts = [];
   let i = 0;
-  globalThis.fetch = async (url, init) => {
+  _setFetchForTests(async (url, init) => {
     attempts.push({ url: String(url), init });
     const outcome = outcomes[Math.min(i++, outcomes.length - 1)];
     if (outcome instanceof Error) throw outcome;
     // Carry a real `headers` object: the debug path reads response headers, and
     // a stub without them hides breakage there behind a passing test.
     return { status: 200, headers: new Headers(), json: async () => outcome };
-  };
+  });
   return attempts;
 }
 
@@ -205,11 +209,11 @@ test("no retry when the remaining budget cannot fit one", async () => {
   // `timeout: 1` — attempt 1 burns most of it, so retrying would abort instantly
   // and replace a real ECONNRESET diagnosis with a generic timeout.
   let calls = 0;
-  globalThis.fetch = async () => {
+  _setFetchForTests(async () => {
     calls++;
     await new Promise((r) => setTimeout(r, 900));
     throw fetchFailed(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }));
-  };
+  });
   const out = await handleSearch({ query: "hi", timeout: 1 });
   assert.equal(calls, 1, "retried into a budget that could not fit it");
   assert.match(textOf(out), /ECONNRESET/, "lost the specific diagnosis to a generic timeout");
@@ -233,7 +237,7 @@ const ALL_TOOLS = [
 ];
 
 function stubJsonReject(err) {
-  globalThis.fetch = async () => ({ status: 200, headers: new Headers(), json: async () => { throw err; } });
+  _setFetchForTests(async () => ({ status: 200, headers: new Headers(), json: async () => { throw err; } }));
 }
 
 test("every tool classifies all three body-read failure shapes under its own label", async () => {
@@ -258,10 +262,10 @@ test("every tool classifies all three body-read failure shapes under its own lab
 
 test("every tool relays a server envelope error verbatim with the server's request_id", async () => {
   for (const [label, invoke] of ALL_TOOLS) {
-    globalThis.fetch = async () => ({
+    _setFetchForTests(async () => ({
       status: 200, headers: new Headers(),
       json: async () => ({ code: 403, msg: "Beta access required", request_id: "20260815SRVENV000001" }),
-    });
+    }));
     const out = await invoke();
     assert.equal(out.isError, true, label);
     const text = textOf(out);
@@ -272,7 +276,7 @@ test("every tool relays a server envelope error verbatim with the server's reque
 
 test("every tool rejects empty input before touching the network", async () => {
   let fetched = false;
-  globalThis.fetch = async () => { fetched = true; throw new Error("must not be called"); };
+  _setFetchForTests(async () => { fetched = true; throw new Error("must not be called"); });
   const EMPTY = [
     () => handleSearch({ query: "  " }),
     () => handleBroadSearch({ query: "" }),

--- a/test/search.test.mjs
+++ b/test/search.test.mjs
@@ -1,8 +1,10 @@
 /**
  * Unit tests for request-body assembly in the search tools (built output).
  *
- * Run with `npm test` (builds first, then `node --test test/`). Global `fetch`
- * is stubbed so no network traffic happens; we assert on the outgoing payload.
+ * Run with `npm test` (builds first, then `node --test test/`). The HTTP
+ * layer's fetch is stubbed through its test seam so no network traffic
+ * happens; we assert on the outgoing payload. (`globalThis.fetch` would be a
+ * no-op to stub: the module fetches through the packaged undici.)
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -12,18 +14,19 @@ process.env.OCTEN_API_KEY = process.env.OCTEN_API_KEY ?? "test-key";
 
 const { searchTool, newsSearchTool, broadSearchTool, handleSearch, handleNewsSearch, handleBroadSearch } =
   await import("../dist/search.js");
+const { _setFetchForTests } = await import("../dist/http.js");
 
-/** Stub global fetch for one call; returns the captured {url, body}. */
+/** Stub the HTTP layer's fetch for one call; returns the captured {url, body}. */
 function captureFetch(responseData = { code: 0, data: { results: [] } }) {
   const captured = {};
-  globalThis.fetch = async (url, init) => {
+  _setFetchForTests(async (url, init) => {
     captured.url = String(url);
     captured.body = JSON.parse(init.body);
     return {
       status: 200,
       json: async () => responseData,
     };
-  };
+  });
   return captured;
 }
 

--- a/test/selfContainedFetch.test.mjs
+++ b/test/selfContainedFetch.test.mjs
@@ -98,6 +98,35 @@ test("a real tool call succeeds through the packaged HTTP stack on the host's ow
   }
 });
 
+test("compressed response bodies decode through the packaged stack", async () => {
+  // The pinned accept-encoding is a promise: every encoding we advertise, the
+  // packaged undici must decode. If a future undici (or a header edit) breaks
+  // gzip or br decode, the body reaches JSON.parse as compressed bytes and the
+  // failure surfaces as "returned non-JSON" — a misdiagnosis, pointing at the
+  // origin when the bug is ours. This exercises the decode path for real; the
+  // header assertion above only proves what we advertise.
+  const { gzipSync, brotliCompressSync } = await import("node:zlib");
+  const envelope = Buffer.from(JSON.stringify({ code: 0, data: { results: [] }, meta: {} }));
+  let enc = "gzip";
+  const upstream = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json", "Content-Encoding": enc });
+    res.end(enc === "br" ? brotliCompressSync(envelope) : gzipSync(envelope));
+  });
+  await new Promise((r) => upstream.listen(0, r));
+  try {
+    for (enc of ["gzip", "br"]) {
+      const result = await callViaStdio(
+        { OCTEN_API_URL: `http://127.0.0.1:${upstream.address().port}` },
+        { query: "decode probe" }
+      );
+      assert.notEqual(result.isError, true,
+        `${enc}-encoded body did not decode: ${result.content?.[0]?.text}`);
+    }
+  } finally {
+    upstream.close();
+  }
+});
+
 test("src/ never touches the host's fetch or its fetch classes", () => {
   // Lint-style guard. Passing global-fetch work off to the packaged dispatcher
   // is exactly the 0.4.1 bug; mixing the two families' Response / Headers /
@@ -112,7 +141,11 @@ test("src/ never touches the host's fetch or its fetch classes", () => {
       for (const pattern of [
         /\bglobalThis\.fetch\b/,
         /\bglobal\.fetch\b/,
-        /(?<![.\w])fetch\s*\(/,          // a bare call — `fetchImpl(`, `undiciFetch(` stay legal
+        // A bare call. The lookbehind rules out member calls (`.fetch(`) and
+        // suffixed look-alikes (`prefetch(`); `fetchImpl(` / `undiciFetch(`
+        // never match at all — no `(` right after `fetch`, and the pattern is
+        // case-sensitive.
+        /(?<![.\w])fetch\s*\(/,
         /\bnew\s+(Response|Headers|Request|FormData)\s*\(/,
         /instanceof\s+(Response|Headers|Request|FormData)\b/,
       ]) {

--- a/test/selfContainedFetch.test.mjs
+++ b/test/selfContainedFetch.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * Regression pins for the undici-8 host incompatibility (0.4.1 → 0.4.2), on
+ * the real stack.
+ *
+ * 0.4.1 built its tuned dispatcher from the packaged undici 6 and handed it to
+ * the host's global `fetch`. That couples two undici versions across the
+ * dispatch-handler protocol: undici 8 — embedded from Node 26 — dropped the
+ * legacy handler compatibility v7 still carried, and rejects the v6 dispatcher
+ * at validation (`InvalidArgumentError: invalid onError method`) before a
+ * single byte is sent. Every tool call on such hosts failed as
+ * `Network error … code=UND_ERR_INVALID_ARG`.
+ *
+ * The fix makes the HTTP stack self-contained: fetch and dispatcher both come
+ * from the packaged undici. These tests drive the real built server over a
+ * real socket — no seam, no stub — so running the suite on a Node whose
+ * embedded undici we cannot dispatch to fails here first, whatever version
+ * that host embeds. The in-process suites cannot catch this class of bug:
+ * their stubs replace exactly the layer that breaks.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SERVER = path.join(ROOT, "dist", "index.js");
+
+/** Drive one tools/call through the stdio server; resolve its result. */
+function callViaStdio(env, args, { killAfterMs = 12000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [SERVER], {
+      env: {
+        ...process.env, OCTEN_API_KEY: "test-key",
+        HTTPS_PROXY: "", https_proxy: "", HTTP_PROXY: "", http_proxy: "",
+        ...env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let out = "";
+    const timer = setTimeout(() => {
+      child.kill();
+      reject(new Error(`no tool response before deadline; stdout:\n${out.slice(0, 500)}`));
+    }, killAfterMs);
+    child.stdout.on("data", (d) => {
+      out += d;
+      for (const line of out.split("\n").filter(Boolean)) {
+        let m;
+        try { m = JSON.parse(line); } catch { continue; }
+        if (m.id === 2) {
+          clearTimeout(timer);
+          child.kill();
+          resolve(m.result);
+          return;
+        }
+      }
+    });
+    const send = (o) => child.stdin.write(JSON.stringify(o) + "\n");
+    send({ jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "1" } } });
+    send({ jsonrpc: "2.0", method: "notifications/initialized" });
+    send({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "search", arguments: args } });
+  });
+}
+
+test("a real tool call succeeds through the packaged HTTP stack on the host's own Node", async () => {
+  // The incident in one assertion: on a host whose embedded undici rejects our
+  // dispatcher, this call — real server process, real socket, no seam — dies
+  // with UND_ERR_INVALID_ARG before the request is sent.
+  let seen = null;
+  const upstream = http.createServer((req, res) => {
+    seen = { headers: req.headers, url: req.url };
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ code: 0, data: { results: [] }, meta: {} }));
+  });
+  await new Promise((r) => upstream.listen(0, r));
+  try {
+    const result = await callViaStdio(
+      { OCTEN_API_URL: `http://127.0.0.1:${upstream.address().port}` },
+      { query: "compat probe" }
+    );
+    assert.notEqual(result.isError, true,
+      `the call failed — on this Node that usually means the dispatcher was ` +
+      `rejected by a foreign fetch: ${result.content?.[0]?.text}`);
+    assert.ok(seen, "the request never reached the origin");
+
+    // The request must carry our credentials and correlation id …
+    assert.equal(seen.headers["x-api-key"], "test-key");
+    assert.match(seen.headers["x-request-id"] ?? "", /^[0-9a-f-]{36}$/);
+    // … and advertise exactly what the packaged undici can decode. Left to a
+    // default this varies by scheme and by which undici does the fetching; an
+    // origin honouring an encoding we cannot decode turns the body to garbage.
+    assert.equal(seen.headers["accept-encoding"], "gzip, deflate, br");
+  } finally {
+    upstream.close();
+  }
+});
+
+test("src/ never touches the host's fetch or its fetch classes", () => {
+  // Lint-style guard. Passing global-fetch work off to the packaged dispatcher
+  // is exactly the 0.4.1 bug; mixing the two families' Response / Headers /
+  // Request classes is its instanceof-shaped sibling (the two are never the
+  // same class, so cross-family instanceof is always false). Any new call site
+  // must import from "undici" — the seam in http.ts, `fetchImpl`, already does.
+  const offenders = [];
+  const srcDir = path.join(ROOT, "src");
+  for (const f of fs.readdirSync(srcDir).filter((f) => f.endsWith(".ts"))) {
+    const text = fs.readFileSync(path.join(srcDir, f), "utf8");
+    text.split("\n").forEach((line, i) => {
+      for (const pattern of [
+        /\bglobalThis\.fetch\b/,
+        /\bglobal\.fetch\b/,
+        /(?<![.\w])fetch\s*\(/,          // a bare call — `fetchImpl(`, `undiciFetch(` stay legal
+        /\bnew\s+(Response|Headers|Request|FormData)\s*\(/,
+        /instanceof\s+(Response|Headers|Request|FormData)\b/,
+      ]) {
+        if (pattern.test(line)) offenders.push(`${f}:${i + 1}: ${line.trim()}`);
+      }
+    });
+  }
+  assert.deepEqual(offenders, [],
+    `global fetch-family usage in src/ — route it through the packaged undici:\n${offenders.join("\n")}`);
+});


### PR DESCRIPTION
## Root cause

Since 0.4.0 the server builds its tuned connection agent from the **packaged undici 6** and hands it as `dispatcher` to the **host's global `fetch`** — coupling two undici versions across the dispatch-handler protocol. undici 8, which Node embeds from 26, removed the legacy handler compatibility that v7 still carried, so the host's fetch rejects the v6 dispatcher at validation, before a single byte is sent:

```
Network error calling Octen Search: code=UND_ERR_INVALID_ARG cause=invalid onError method
```

**Impact: 100% of tool calls fail on Node 26+ hosts** (both dispatcher branches — plain `Agent` and `EnvHttpProxyAgent`). Verified boundary, not assumed:

| Host Node | embedded undici | 0.4.1 | this PR |
|---|---|---|---|
| 18.17 / 20 / 22 | v5–v6 | ✅ | ✅ |
| 24.13 | 7.18.2 (kept legacy compat) | ✅ | ✅ |
| 26.7 | 8.9.0 (compat removed) | ❌ every call | ✅ |

## Fix

The HTTP stack is now **self-contained**: `fetch` is imported from the same packaged undici that builds the dispatcher, so the host's embedded undici is out of the picture entirely — for this incompatibility and for future protocol changes alike. Also pins `accept-encoding: gzip, deflate, br` — exactly what the packaged undici decodes — instead of inheriting a scheme- and version-dependent default (verified: explicit header does not disable auto-decompression, gzip and br both decode).

## Tests

- Pre-fix baseline on Node 26: **8/57 failing** (all real-socket suites); post-fix: **59/59 green on 18.17, 22, 24, 26** locally.
- New `test/selfContainedFetch.test.mjs`:
  - real-socket regression — drives the built server through the packaged stack on the host's own Node, asserts success + credentials/correlation/accept-encoding headers on the wire;
  - lint-style guard — no global `fetch` / `Response` / `Headers` / `Request` usage in `src/` (a source-scan test instead of an ESLint dependency; the repo has no lint infra and this adds none).
- In-process suites migrated from stubbing `globalThis.fetch` (now a no-op — it would silently hit the real network) to a test seam `_setFetchForTests` in `http.ts`.
- CI matrix extended to `18/20/22/24/26` — 24 and 26 embed the undici versions this bug needs.

## Live verification

- Real calls to `api.octen.ai` on Node 26 (direct **and** through a real local HTTP proxy) and Node 18.17: OK.
- Installed in Claude Code with the server running on Node 26 (the exact field environment): real Claude → MCP → live API call returns results.

## Notes

- `engines` stays `>=18.17` (undici 6's own floor; the plan's `>=18` would overpromise).
- undici stays on 6.x (`^6.28.0`); the v7+ upgrade is a separate task.
- README gains a compatibility note: 0.4.1 and below need Node <= 24; 0.4.2+ runs everywhere supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)