### PR TITLE
feat(http): remote HTTP transport with OAuth resource-server support (0.5.0)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+test
+docs
+assets
+.git
+.github
+*.tgz

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,184 @@
+name: Image
+
+# Builds the remote HTTP entry into a container and pushes it to ACR.
+#
+# There was no such workflow: all ten existing tags in service/octen-mcp were
+# pushed by hand, and the newest of them sat thirteen commits behind the branch
+# — an image that predated base64 image input, the 6 MiB body cap and the
+# schema alignment, while reading as "the latest one".
+#
+# Deliberately NOT triggered by pull_request. This repository is public. GitHub
+# withholds secrets from fork pull requests, so such a run would fail rather
+# than leak, but a job holding registry credentials has no business running on
+# a proposed change at all. Use workflow_dispatch to build any branch — the ref
+# picker covers the "build my PR branch and test it" case.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push to ACR. Unchecked = build and smoke-test only."
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Fail here rather than at `docker push`, where the error is a registry
+      # authentication failure that reads like an outage.
+      # Named ACR_* rather than SERVER/USER/PWD: the latter two are standard
+      # shell variables. `PWD` is the working directory and `USER` the login
+      # name, so an emptiness check on them is always false and `docker login`
+      # would have been handed the working directory as a password.
+      - name: Check registry credentials are configured
+        if: inputs.push != false
+        env:
+          ACR_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
+          ACR_USERNAME: ${{ secrets.ACR_USER }}
+          ACR_PASSWORD: ${{ secrets.ACR_PWD }}
+        run: |
+          missing=""
+          [ -n "$ACR_SERVER" ]   || missing="$missing ACR_LOGIN_SERVER"
+          [ -n "$ACR_USERNAME" ] || missing="$missing ACR_USER"
+          [ -n "$ACR_PASSWORD" ] || missing="$missing ACR_PWD"
+          if [ -n "$missing" ]; then
+            echo "::error::missing repository secret(s):$missing"
+            exit 1
+          fi
+
+      - name: Work out the tags
+        id: tags
+        env:
+          ACR_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
+        run: |
+          set -euo pipefail
+          # Full SHA, matching every tag already in the registry and whatever
+          # the deployment manifests pin.
+          echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "repo=${ACR_SERVER:-local}/service/octen-mcp" >> "$GITHUB_OUTPUT"
+
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          # A version tag must agree with package.json, or the image carries a
+          # name that does not describe what is inside it.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            want="${GITHUB_REF_NAME#v}"
+            if [ "$want" != "$version" ]; then
+              echo "::error::tag ${GITHUB_REF_NAME} does not match package.json ($version)"
+              exit 1
+            fi
+            echo "version_tag=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version_tag=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        env:
+          REPO: ${{ steps.tags.outputs.repo }}
+          SHA: ${{ steps.tags.outputs.sha }}
+        run: docker build -t "$REPO:$SHA" .
+
+      # The point of building here is that nobody has to trust the build. A
+      # container that starts, serves its health probe and answers an
+      # unauthenticated tools/list is the smallest check that the image is
+      # actually runnable — a Dockerfile can build cleanly and still produce
+      # something that exits on boot.
+      - name: Smoke-test the image
+        env:
+          REPO: ${{ steps.tags.outputs.repo }}
+          SHA: ${{ steps.tags.outputs.sha }}
+          VERSION: ${{ steps.tags.outputs.version }}
+        run: |
+          set -euo pipefail
+          cid=$(docker run -d -p 18080:8080 -e PORT=8080 "$REPO:$SHA")
+          trap 'docker logs "$cid" 2>&1 | tail -40; docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:18080/healthz >/dev/null 2>&1; then break; fi
+            if [ "$i" = 30 ]; then echo "::error::/healthz never came up"; exit 1; fi
+            sleep 1
+          done
+          echo "healthz ok"
+
+          # Both Accept types are required by the Streamable HTTP transport;
+          # sending only application/json gets a 406 that looks like a server
+          # fault. Judged on the HTTP status, not on the body — a JSON-RPC
+          # error still arrives as 200.
+          code=$(curl -sS -o /tmp/tools.json -w '%{http_code}' \
+            -X POST http://127.0.0.1:18080/mcp \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}')
+          if [ "$code" != "200" ]; then
+            echo "::error::unauthenticated tools/list returned $code"
+            cat /tmp/tools.json
+            exit 1
+          fi
+          # The transport answers as SSE, so the body is a `data: {json}` line
+          # rather than bare JSON. Checked for a non-empty roster containing a
+          # known tool: `grep '"tools"'` alone also passes on `"tools":[]`,
+          # which is a server that came up with nothing registered.
+          roster=$(sed -n 's/^data: //p' /tmp/tools.json | head -1)
+          echo "$roster" | grep -q '"tools":\[{' || {
+            echo "::error::tools/list returned an empty or unparseable roster"
+            cat /tmp/tools.json; exit 1; }
+          echo "$roster" | grep -q '"name":"search"' || {
+            echo "::error::the roster does not contain the search tool"
+            cat /tmp/tools.json; exit 1; }
+          echo "tools/list ok"
+
+          # The image must report the version it was built from; a stale
+          # package.json copied into the wrong layer is otherwise invisible.
+          docker logs "$cid" 2>&1 | grep -q "v${VERSION}" || {
+            echo "::error::the container does not report v${VERSION}"; exit 1; }
+          echo "version ok: v${VERSION}"
+
+      - name: Push
+        if: inputs.push != false
+        env:
+          ACR_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
+          ACR_USERNAME: ${{ secrets.ACR_USER }}
+          ACR_PASSWORD: ${{ secrets.ACR_PWD }}
+          REPO: ${{ steps.tags.outputs.repo }}
+          SHA: ${{ steps.tags.outputs.sha }}
+          VERSION: ${{ steps.tags.outputs.version }}
+          VERSION_TAG: ${{ steps.tags.outputs.version_tag }}
+        run: |
+          set -euo pipefail
+          printf %s "$ACR_PASSWORD" | docker login "$ACR_SERVER" -u "$ACR_USERNAME" --password-stdin
+          docker push "$REPO:$SHA"
+          if [ "$VERSION_TAG" = "true" ]; then
+            docker tag "$REPO:$SHA" "$REPO:v$VERSION"
+            docker push "$REPO:v$VERSION"
+          fi
+
+      - name: Summary
+        if: always()
+        env:
+          REPO: ${{ steps.tags.outputs.repo }}
+          SHA: ${{ steps.tags.outputs.sha }}
+          PUSHED: ${{ inputs.push != false }}
+        run: |
+          {
+            echo "\`$REPO:$SHA\`"
+            if [ "$PUSHED" = "true" ]; then
+              echo ""
+              echo "Pushed. Deploy by pinning this SHA — the manifests live with the deployment spec, not here."
+            else
+              echo ""
+              echo "Built and smoke-tested only; not pushed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -85,11 +85,33 @@ jobs:
             echo "version_tag=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Platform pinned, not inherited from the runner. The cluster is amd64,
+      # and an image built for anything else is rejected at pull time with
+      # `no match for platform in manifest` — which is a deploy-time failure,
+      # far from whoever built it. GitHub is rolling out arm64 runners, so
+      # "ubuntu-latest happens to be amd64" is not something to rely on.
       - name: Build
         env:
           REPO: ${{ steps.tags.outputs.repo }}
           SHA: ${{ steps.tags.outputs.sha }}
-        run: docker build -t "$REPO:$SHA" .
+        run: docker build --platform linux/amd64 -t "$REPO:$SHA" .
+
+      # Asserted separately from the smoke test below, which cannot catch this:
+      # running the container on the machine that built it succeeds precisely
+      # when the architectures match. This is how an arm64 image reached the
+      # registry looking fully verified.
+      - name: Check the image is linux/amd64
+        env:
+          REPO: ${{ steps.tags.outputs.repo }}
+          SHA: ${{ steps.tags.outputs.sha }}
+        run: |
+          set -euo pipefail
+          got=$(docker image inspect "$REPO:$SHA" --format '{{.Os}}/{{.Architecture}}')
+          if [ "$got" != "linux/amd64" ]; then
+            echo "::error::image is $got, but the cluster pulls linux/amd64"
+            exit 1
+          fi
+          echo "platform ok: $got"
 
       # The point of building here is that nobody has to trust the build. A
       # container that starts, serves its health probe and answers an
@@ -103,7 +125,7 @@ jobs:
           VERSION: ${{ steps.tags.outputs.version }}
         run: |
           set -euo pipefail
-          cid=$(docker run -d -p 18080:8080 -e PORT=8080 "$REPO:$SHA")
+          cid=$(docker run -d --platform linux/amd64 -p 18080:8080 -e PORT=8080 "$REPO:$SHA")
           trap 'docker logs "$cid" 2>&1 | tail -40; docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
 
           for i in $(seq 1 30); do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,294 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-08-31
+
+### Added
+- **Remote HTTP transport (preview)** — `octen-mcp-http` runs the same server
+  over stateless Streamable HTTP, for hosting behind a URL instead of spawning
+  per client:
+  - without an authorization server configured, `initialize` and `tools/list`
+    are unauthenticated and credentials are enforced at `tools/call`, where a
+    missing key fails with header guidance rather than an opaque handshake
+    refusal. With one configured, an uncredentialed request is answered 401 +
+    `WWW-Authenticate` instead — see below;
+  - both `x-api-key: <key>` and `Authorization: Bearer <key>` are accepted —
+    some clients can only send the latter;
+  - one server instance per request, key bound by closure. The environment's
+    `OCTEN_API_KEY` is deliberately **not** a fallback for HTTP callers: an
+    unauthenticated request must fail, not silently ride the deployment's own
+    credential. Guarded by tests including a deterministic staggered-body
+    interleaving case, since the race window for shared-key-state bugs sits
+    inside the body-read await where ordinary concurrent tests cannot land;
+  - `GET /healthz` liveness with no upstream round-trip.
+
+  The stdio entry is unchanged in behavior; both entries now assemble the same
+  server from `src/server.ts`, so the transports cannot drift apart.
+
+- **OAuth 2.1 resource server** for the HTTP transport — enabled only when both
+  `OCTEN_OAUTH_AUTHORIZATION_SERVER` and `OCTEN_MCP_RESOURCE` are set, so a
+  self-hosted instance never advertises an authorization server it cannot
+  honour. RS256 access tokens are verified against the AS's JWKS with
+  `node:crypto` (no new dependency), then exchanged for the grant's API key
+  through an authenticated internal endpoint — the token itself never carries a
+  key. RFC 9728 protected-resource metadata is served at both the bare and the
+  resource-path-derived well-known, and any uncredentialed `POST /mcp` answers
+  a 401 challenge, which is what makes a client start the flow at all.
+
+  Token problems answer **401 + `WWW-Authenticate`** so clients auto-refresh;
+  backend problems answer **503** so a client does not burn its refresh flow on
+  our outage. Bare API keys never enter this path.
+
+- **Three ways to pass a key**, tried in order: `x-api-key`,
+  `Authorization: Bearer`, and an `octenApiKey` query parameter. The query
+  form exists for clients that can be handed nothing but a URL, e.g. a hosted
+  connector UI whose only input is the endpoint. It is not needed for Claude
+  Desktop: that config spawns `mcp-remote`, which does take `--header` and
+  `--header-file` (the latter keeps the key out of the process arguments).
+  A header always wins, so nothing that can send
+  one is downgraded. A key in a URL reaches proxy logs, browser history and
+  `Referer` headers — none of which this server controls — so the one thing it
+  can do, it does: query values are redacted from its own logs, whole rather
+  than truncated.
+- **`POST /mcp/oauth` and `?login` force the authorization challenge** even
+  when a credential is present. Without it there is no route from an
+  already-configured API key to OAuth, because the key stops the challenge from
+  ever being sent. (This is not the old `?login` gate returning: an
+  uncredentialed request is still challenged everywhere.)
+- **`?tools=a,b` narrows a connection's tool roster**, enforced on `tools/call`
+  as well as `tools/list` — filtering only the listing would leave every tool
+  callable and the filter decorative. Clients load every advertised tool's full
+  schema into the model's context, so this is a context saving rather than a
+  capability switch. An unknown name, or a selection that leaves nothing, is a
+  400 naming the bad entry and listing the real ones: silently narrowing
+  produces a connection that looks healthy and is missing a tool, which sends
+  whoever debugs it to look at the tool instead of at the spelling in their
+  URL. Beta tools that the Beta switch has turned off read as names that do not
+  exist, so a selection can never reach past that switch.
+
+- **Tool arguments are checked against the schema each tool publishes.** The
+  MCP SDK does not enforce `inputSchema`, so every constraint in it was
+  advertising: measured, `count: 999999` against `maximum: 100`, a
+  5000-character `query` against `maxLength: 500`, and a 5000-entry array
+  against `maxItems: 1000` were each relayed to the upstream API intact. An
+  agent that read the schema and respected it gained nothing over one that
+  ignored it, and when it did get something wrong the answer came back as an
+  opaque upstream 400 rather than a sentence naming the field.
+
+  The validator reads the same schema object that is sent to clients, never a
+  copy of its rules — a duplicated rule set drifts the first time someone edits
+  a schema, and drifts silently. It implements exactly the vocabulary those
+  schemas use, and a test asserts no schema ever declares a keyword it would
+  skip, since an ignored keyword turns a published constraint back into
+  advertising with nobody the wiser.
+
+  Parameters outside a tool's `properties` are refused rather than relayed:
+  the properties list is the published interface, and forwarding anything else
+  made this server a pass-through for arbitrary JSON. Note for existing
+  callers: `news_search` publishes no `topic` (it is fixed to news), so passing
+  one is now an error instead of being silently overridden.
+
+- **The HTTP body cap now defaults to 6 MiB**, so `image_search`'s `image_data`
+  works without configuration. A default below the largest argument a tool
+  accepts means the tool is advertised and unusable over that transport, and
+  the client sees a `413` with no obvious connection to the picture it sent.
+- **`OCTEN_MCP_MAX_INFLIGHT_BODY`** bounds the total bytes all in-flight bodies
+  hold at once, default 24 MiB. The per-request cap stops one enormous request
+  and does nothing about many ordinary ones: with the per-request cap at 6 MiB,
+  forty concurrent 5 MB bodies measured 772 MB resident against a 768 MiB
+  container — an OOM kill reachable by anyone holding a key, with no single
+  request breaking a rule. Over the budget, the newest request is shed with
+  `503` + `Retry-After`, because this is capacity rather than a bad call.
+
+  The budget is deliberately small relative to the bytes it guards: a 5 MB
+  ASCII body is ~10 MB as a UTF-16 string and exists two or three times over
+  (concatenated, parsed, re-serialised upstream), so resident cost runs about
+  ten times the budget. Verified in a real 768 MiB container: sixty concurrent
+  5 MB requests peak at 342 MiB with no OOM kill.
+
+- **Install documentation rebuilt around the hosted endpoint**
+  (`https://mcp.octen.ai/mcp`, now live). Remote is the first path a reader
+  meets; local stdio follows as the alternative for clients without remote
+  support. Per-client configuration is spelled out because the JSON key differs
+  between them — `url`, `serverUrl`, `httpUrl`, or `servers` with an explicit
+  `type` — and getting it wrong means the server is simply never contacted,
+  with nothing in any log to say so. Stdio-only clients get the `mcp-remote`
+  bridge, including the detail that `--header` takes no space after the colon.
+
+  Added: a parameter table per tool, transcribed from the schemas the tools
+  publish, and a troubleshooting section covering the failures that do not look
+  like what they are — a `406` from an incomplete `Accept` header reads as an
+  auth problem, and a wrong config key looks like the server being down.
+
+  Corrected: the README claimed `mcp-remote` has no `--header` option. It has
+  had one for several releases; the claim came from a report citing 0.2.4
+  against a current 0.8.2. The query-string credential remains for clients that
+  accept nothing but a URL, which is a smaller set than that claim implied.
+
+### Fixed
+- **`image_search` gained `image_data`.** The API's image input takes either a
+  URL or base64 bytes; only the URL form was offered, so an image you hold
+  rather than one already on the web could not be searched at all. Up to 5MB
+  encoded, matching the documented ceiling — measured on the encoded string,
+  which is what the API bounds. A `data:` URI is unwrapped rather than refused:
+  its payload *is* the base64, and it is the form every browser and screenshot
+  tool produces.
+
+  Note for the HTTP transport: base64 travels inside the JSON-RPC body, so
+  `OCTEN_MCP_MAX_BODY` (default 1 MiB) must be raised above the image or the
+  request is refused. The `413` now names that variable — a byte count alone
+  does not tell an operator which knob to turn.
+- **`image_search` advertised the one input combination the API refuses, and
+  could not express the one it documents.** The `inputs` array takes exactly one
+  entry — one text input or one image input, never both. This tool required
+  `query` and described `image_url` as usable "in addition" to it, so passing
+  both (the advertised path) was answered upstream with `Invalid params. Inputs
+  exceeds 1 entries`, while searching by reference image alone — documented and
+  supported — could not be expressed at all. `query` is no longer required,
+  exactly one of the two is, and asking for both is refused locally with a
+  message that names the choice instead of relaying a params error.
+- **`include_videos` removed from `search` / `news_search` / `broad_search`.**
+  The API reference documents no such parameter for that endpoint. It did have
+  an effect when sent — responses carried a `videos` field only with it set —
+  but advertising a parameter the API does not document is promising something
+  nobody has committed to, and since the schemas became a gate that promise is
+  enforced against callers. `extract` keeps all three of its media flags; those
+  are documented. The video renderer stays too: if a response ever carries
+  `videos` regardless, dropping them silently is the defect above.
+- **Declared parameter limits did not match the published API.** Seven of them,
+  across four tools. Two were rejecting calls the API serves: `exclude_domains`
+  was capped at 150 against a documented 1200, and every domain longer than 30
+  characters was refused against a documented 60. Three were missing entirely
+  (`urls` item length, `max_age_seconds` upper bound, `html_snippet.max_tokens`
+  upper bound), so nothing bounded them at all.
+
+  This mattered little while the schemas were advertising; it started costing
+  users the moment they became a gate. A limit stricter than the API's refuses
+  work the API would do, and a looser one defers the failure upstream where the
+  message is worse. `test/apiContract.test.mjs` now pins every documented
+  limit and enum, so the next divergence fails a test instead of a user's call.
+- **`include_images` / `include_videos` returned no URLs.** The tools promise,
+  in their own descriptions, to "return media URLs per result"; what came back
+  was a count. Measured against the live API: a search whose result carried 101
+  image URLs rendered as the single line `**Images:** 101`, and the only image
+  links anywhere in the output were favicons. `extract` did the same for its
+  images, videos and audio — 37 / 14 / 3 URLs, none of them printed. Setting
+  the flag cost an upstream fetch and returned nothing actionable.
+
+  Each entry now prints as `url — description`, capped at ten per list with the
+  true total stated alongside. The caption matters as much as the link: on news
+  results it carries what was photographed, where, when, and the photographer's
+  credit, and a bare URL leaves a model with nothing it can say about the
+  picture. The cap is there because one result really can carry a hundred
+  images, and pasting all of them into a model's context costs more than the
+  answer is worth — but a cap the reader cannot see is the same silent drop in
+  a smaller size, so the total is always stated.
+- **`cover_image` rendered as `[object Object]`.** The field arrives as
+  `{url, description}` and search interpolated the object. `extract` had
+  already been reading `.url` correctly — the two had drifted, which is also
+  how the counting bug above came to exist in two places. Both now share one
+  renderer rather than a copy each.
+- **The OAuth flow never started.** The 401 challenge — the only trigger MCP
+  clients act on — fired solely on a `?login` entrypoint, so a client given the
+  plain `/mcp` URL got 200 from `initialize`, concluded the server needed no
+  authorization, listed tools, and failed at the first `tools/call` with a
+  message pointing at manual API-key setup. Connected, and never able to
+  authorize. Confirmed on pre before the fix: `initialize`, `tools/list` and
+  `tools/call` all answered 200 with no `WWW-Authenticate` on any of them.
+
+  An uncredentialed request now gets 401 + `WWW-Authenticate` on every method
+  when an authorization server is configured. The trade is that anonymous
+  `tools/list` is no longer possible against such a deployment; deployments
+  without an authorization server are unchanged, since there would be nowhere
+  to send the client.
+- **JWTs this server cannot verify were retried as API keys.** The structural
+  gate that routes a bearer value to the OAuth path or the API-key path
+  required `alg: RS256` *and* a `kid`, so anything token-shaped but
+  unverifiable fell through to the key path: measured, `alg: none`, an HS256
+  token, and one missing `kid` were each forwarded verbatim to the upstream as
+  an API key and answered HTTP 200 with a tool-level "Invalid API Key". A
+  client holding a bearer token needs 401 + a challenge to know it should
+  re-authorize; a tool error reads as a backend fault to retry, so it never
+  does. It also put a whole bearer token — possibly minted for another
+  audience — into the API gateway's logs as if it were a key. The gate is now
+  shape-only (three segments, header with a string `alg`), and the specific
+  reason comes back as a 401. Values that are not token-shaped are still keys,
+  and a wrong key still earns the tool-level "check your key" error.
+
+  Not affected, verified rather than assumed: an *expired* token already took
+  the OAuth path and answered 401, because tokens from the authorization server
+  always carry a `kid`.
+- **The request-size cap could be answered with a connection reset instead of a
+  413.** Hanging up while the client is still sending resets the connection,
+  and a reset discards the response bytes still in flight — measured both ways:
+  a client that stopped after 128 KB received the 413, one that kept sending
+  received only `ECONNRESET`. The body is now drained and discarded (bounded by
+  `OCTEN_MCP_BODY_DRAIN_MS`, default 2s) so the answer survives the close.
+- **Remote kill via a hostile token header.** A `kid` containing CRLF reached
+  `res.writeHead` through the `WWW-Authenticate` challenge; the resulting
+  `ERR_INVALID_CHAR` escaped an async handler as an unhandled rejection and
+  ended the process. Unauthenticated and one request per kill — with a single
+  replica that is a full outage. Fixed in three places: the value is sanitised
+  at its source, `error_description` is filtered to the RFC 6750 charset, and
+  the request handler now has an error boundary so no future throw can exceed
+  one failed request.
+- **JWKS amplification.** An unknown `kid` triggered a JWKS refetch per
+  request, with no cross-request limit — measured at 11 fetches from 10
+  unauthenticated requests, aimed at our own authorization server. Refetches
+  are now rate-limited and concurrent misses share one fetch. Rotation still
+  picks up a new key, delayed by at most the cooldown.
+- **A misconfigured resource URL used to pass startup and every health probe**,
+  then kill the process on the first `?login` — a pod that is healthy until
+  someone uses it. Both OAuth URLs are now parsed at startup and an unusable
+  value stops the process there.
+- **The OAuth path bypassed the tuned HTTP dispatcher**, so JWKS and grant
+  resolution ignored the proxy environment (the 0.4.0 fix, missing from the
+  code added after it) and re-handshaked on every call.
+- **Generic failures replaced with specific ones.** `fetch failed`,
+  `Authorization backend temporarily unavailable`, `Invalid or expired access
+  token` and `Internal server error` each fit a dozen unrelated causes, which
+  is what makes a report unactionable. Every failure now names the dependency
+  and the reason: which endpoint, which transport code or HTTP status, how long
+  a token has been expired, both sides of an audience mismatch, and whether the
+  caller should retry or re-authorize. Internal addresses are still never
+  disclosed.
+- **Environment overrides could be disabled by a typo.** `OCTEN_MCP_MAX_BODY`
+  and `OCTEN_DRAIN_TIMEOUT_MS` were parsed with a bare `Number()`, so a
+  non-numeric value became `NaN` — silently removing the body cap and turning
+  the drain deadline into an infinite one. Both now fall back, and the drain
+  logs the budget it actually resolved to.
+- **Requests blocked in credential resolution were invisible to the drain**, so
+  SIGTERM could exit underneath one. They are counted from arrival now.
+- **A trailing slash on `OCTEN_OAUTH_AUTHORIZATION_SERVER` refused every
+  token.** The value is used two ways and a trailing slash breaks both: the
+  JWKS URL becomes `…//api/oauth/jwks`, and `iss` is compared byte-for-byte
+  against a value no authorization server emits with a trailing slash. The
+  process started, every health probe passed, and 100% of tokens were rejected
+  — measured. Refused at startup now, because the rejection message prints two
+  strings that differ by the one character nobody sees.
+- **A trailing slash on the endpoint answered 404.** `…/mcp/` is the commonest
+  paste artifact in a URL a human copies into a client config; answering it
+  with 404 makes a working deployment look broken for a reason nobody
+  inspects. Both spellings are accepted now.
+- **A burst on one grant made one resolve-key call per request** — measured at
+  eight for eight simultaneous calls. That burst is what an agent firing
+  several tools at once right after authorizing looks like, so the
+  dependency's worst moment was also its most likely one. In-flight
+  resolutions are shared now, as the JWKS path already did.
+- **The advertised metadata URL was hardcoded to `/mcp`** rather than derived
+  from the resource path, so an instance mounted elsewhere pointed clients at a
+  document it does not serve.
+
+### Changed
+- The grant→key cache lifetime is now `OCTEN_OAUTH_RESOLVE_CACHE_TTL_MS`
+  (default 60000, `0` disables caching). This is the revocation-propagation
+  window — measured on pre, a revoked token still worked at t=45s and was
+  refused at t=60s — and it is a deliberate trade rather than an implementation
+  detail: resolving on every call would put a synchronous dependency on the
+  authorization server in front of every tool call. It is also an increment on
+  top of the access token's own ~3600s lifetime, not the whole exposure.
+
+
 ## [0.4.2] — 2026-08-19
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Runtime image for the remote HTTP entry (octen-mcp-http).
+#
+# The stdio entry stays an npm package spawned by MCP clients; this image
+# exists only for the hosted deployment (mcp.octen.ai) and self-hosters.
+# Health checks are NOT declared here: the target platform is Kubernetes,
+# which ignores Dockerfile HEALTHCHECK and uses the probes in deploy/k8s/.
+
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json tsconfig.json ./
+RUN npm ci
+COPY src ./src
+RUN npm run build && npm prune --omit=dev
+
+FROM node:22-slim
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+# Non-root: the process needs nothing beyond an outbound socket.
+USER node
+EXPOSE 8080
+# Structured logs by default in the container; unset OCTEN_MCP_LOG to get the
+# human-readable format back when debugging a container locally.
+ENV OCTEN_MCP_LOG=json
+CMD ["node", "dist/httpServer.js"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Core capabilities:
 - **`search` / `news_search`**: search the live web with domain, text, language, and time filters.
 - **`broad_search`**: decompose a query into multiple sub-queries, search them concurrently, and return results grouped per sub-query for broad coverage.
 - **`extract`**: turn one or more URLs into clean, LLM-ready content.
-- **`image_search`** (In Beta — contact us for beta access): search the web for images by text query, optionally with a reference image.
+- **`image_search`** (In Beta — contact us for beta access): search the web for images by text query, by a reference image URL, or by base64 image data — exactly one of the three.
 - **`video_search`** (In Beta — contact us for beta access): search the web for videos by text query.
 
 What makes Octen useful for agents is that `extract` returns more than page text. Each successful result also includes:
@@ -41,16 +41,153 @@ Clean highlights, optional `full_content`, and page labels keep model context re
 
 You need an `OCTEN_API_KEY` from [octen.ai](https://octen.ai).
 
-> **Node compatibility:** 0.4.2 and later run on every supported Node (>= 18.17),
-> including Node 26+. Versions 0.4.1 and below fail every call on hosts whose
-> embedded undici is v8+ (Node 26 and later) with
-> `Network error … code=UND_ERR_INVALID_ARG cause=invalid onError method` —
-> if you see that error, upgrade the package (or run on Node <= 24).
+**Two ways to connect.** Both serve the same six tools.
 
-[![Install in VS Code](https://img.shields.io/badge/Install%20in-VS%20Code-007ACC?logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=octen&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22Octen%20API%20Key%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22octen-mcp%22%5D%2C%22env%22%3A%7B%22OCTEN_API_KEY%22%3A%22%24%7Binput%3AapiKey%7D%22%7D%7D)
-[![Install in VS Code Insiders](https://img.shields.io/badge/Install%20in-VS%20Code%20Insiders-24bfa5?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=octen&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22Octen%20API%20Key%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22octen-mcp%22%5D%2C%22env%22%3A%7B%22OCTEN_API_KEY%22%3A%22%24%7Binput%3AapiKey%7D%22%7D%7D&quality=insiders)
+| | Endpoint | When |
+|---|---|---|
+| **Hosted (recommended)** | `https://mcp.octen.ai/mcp` | Nothing to install or update. Works with any client that speaks remote MCP. |
+| **Local** | `npx -y octen-mcp` | Clients without remote support, air-gapped setups, or when you want the process on your own machine. |
 
-For most MCP clients, the config is:
+> **Node compatibility (local only):** 0.4.2 and later run on every supported
+> Node (>= 18.17), including Node 26+. Versions 0.4.1 and below fail every call
+> on hosts whose embedded undici is v8+ (Node 26 and later) with
+> `Network error … code=UND_ERR_INVALID_ARG cause=invalid onError method` — if
+> you see that error, upgrade the package (or run on Node <= 24).
+
+## Connect to the hosted endpoint
+
+### Passing your key
+
+Three ways, tried in this order. **Prefer a header** — a key in a URL is
+exposed to proxy logs, browser history and `Referer` headers.
+
+| Form | Use when |
+|---|---|
+| `x-api-key: <key>` | The default. |
+| `Authorization: Bearer <key>` | Your client only offers one header field. |
+| `?octenApiKey=<key>` appended to the URL | Your client accepts nothing but a URL. |
+
+Or use **OAuth** and paste no key at all — see [Signing in instead](#signing-in-instead).
+
+### By client
+
+**Claude Code**
+
+```bash
+claude mcp add --transport http octen https://mcp.octen.ai/mcp --header "x-api-key: your-key-here"
+```
+
+**Cursor** — `~/.cursor/mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "octen": {
+      "url": "https://mcp.octen.ai/mcp",
+      "headers": { "x-api-key": "your-key-here" }
+    }
+  }
+}
+```
+
+**VS Code** — `.vscode/mcp.json` (workspace) or the user config. Note `servers`,
+not `mcpServers`, and the explicit `type`:
+
+```json
+{
+  "servers": {
+    "octen": {
+      "type": "http",
+      "url": "https://mcp.octen.ai/mcp",
+      "headers": { "x-api-key": "your-key-here" }
+    }
+  }
+}
+```
+
+**Codex**
+
+```bash
+codex mcp add octen --url https://mcp.octen.ai/mcp --header "x-api-key: your-key-here"
+```
+
+**Windsurf** — `~/.codeium/windsurf/mcp_config.json`. The key is `serverUrl`,
+not `url`:
+
+```json
+{
+  "mcpServers": {
+    "octen": {
+      "serverUrl": "https://mcp.octen.ai/mcp",
+      "headers": { "x-api-key": "your-key-here" }
+    }
+  }
+}
+```
+
+**Gemini CLI** — `~/.gemini/settings.json`. The key is `httpUrl`:
+
+```json
+{
+  "mcpServers": {
+    "octen": {
+      "httpUrl": "https://mcp.octen.ai/mcp",
+      "headers": { "x-api-key": "your-key-here" }
+    }
+  }
+}
+```
+
+**Clients that only speak stdio** (Claude Desktop, Zed, Warp, Raycast, Cline)
+reach a remote server through the `mcp-remote` bridge. Note there is **no space
+after the colon** in `--header` — the value is split on the first one:
+
+```json
+{
+  "mcpServers": {
+    "octen": {
+      "command": "npx",
+      "args": [
+        "-y", "mcp-remote",
+        "https://mcp.octen.ai/mcp",
+        "--header", "x-api-key:your-key-here"
+      ]
+    }
+  }
+}
+```
+
+If a client cannot pass a header at all and takes only a URL, put the key in
+the URL instead: `https://mcp.octen.ai/mcp?octenApiKey=your-key-here`.
+
+### Signing in instead
+
+If the deployment is configured with an authorization server — the hosted one
+is — a request with no credential is answered `401` +
+`WWW-Authenticate: Bearer resource_metadata="…"`. That is the signal MCP
+clients use to start an OAuth flow, so a client that supports OAuth will offer
+to sign you in rather than ask for a key.
+
+To move a connection that already has a key onto OAuth, point it at
+`https://mcp.octen.ai/mcp/oauth` (or append `?login`). That path issues the
+challenge even when a key is present, which is the only way to trigger the
+switch — with a key attached, the ordinary endpoint has no reason to.
+
+### Loading fewer tools
+
+`?tools=search,extract` limits a connection to the tools you name, for both
+`tools/list` and `tools/call`:
+
+```
+https://mcp.octen.ai/mcp?tools=search,extract
+```
+
+Clients load every advertised tool's full schema into the model's context, so
+narrowing the set is a real saving when you only need one or two. An unknown
+name is refused with a `400` listing the valid ones, rather than a connection
+that quietly comes up short.
+
+## Run it locally instead
 
 ```json
 {
@@ -58,15 +195,14 @@ For most MCP clients, the config is:
     "octen": {
       "command": "npx",
       "args": ["-y", "octen-mcp"],
-      "env": {
-        "OCTEN_API_KEY": "your-key-here"
-      }
+      "env": { "OCTEN_API_KEY": "your-key-here" }
     }
   }
 }
 ```
 
-### Install command by client
+[![Install in VS Code](https://img.shields.io/badge/Install%20in-VS%20Code-007ACC?logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=octen&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22Octen%20API%20Key%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22octen-mcp%22%5D%2C%22env%22%3A%7B%22OCTEN_API_KEY%22%3A%22%24%7Binput%3AapiKey%7D%22%7D%7D)
+[![Install in VS Code Insiders](https://img.shields.io/badge/Install%20in-VS%20Code%20Insiders-24bfa5?logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=octen&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22apiKey%22%2C%22description%22%3A%22Octen%20API%20Key%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22octen-mcp%22%5D%2C%22env%22%3A%7B%22OCTEN_API_KEY%22%3A%22%24%7Binput%3AapiKey%7D%22%7D%7D&quality=insiders)
 
 | Agent | One-line install |
 |--|--|
@@ -79,12 +215,39 @@ For most MCP clients, the config is:
 
 ### Config file locations
 
-For clients without a CLI installer, drop the JSON config above into:
-
 - **Claude Desktop**: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
 - **Cursor**: `~/.cursor/mcp.json`
 - **VS Code workspace**: `.vscode/mcp.json` (use `servers` instead of `mcpServers`)
-- **Windsurf / Cline / other clients**: paste it into that client's MCP settings
+- **Windsurf**: `~/.codeium/windsurf/mcp_config.json`
+- **Gemini CLI**: `~/.gemini/settings.json`
+- **Cline / other clients**: paste it into that client's MCP settings
+
+## Troubleshooting
+
+**`401` on every call.** No credential reached the server. Check the header
+name — `x-api-key`, or `Authorization: Bearer` — and, if you are using
+`mcp-remote`, that there is no space after the colon in `--header`.
+
+**The tools do not appear.** Most clients read MCP config once at startup;
+restart the client after editing it. If the config uses the wrong key for your
+client (`url` vs `serverUrl` vs `httpUrl`), the server is never contacted at
+all — see the per-client sections above.
+
+**`406 Not Acceptable`.** The request's `Accept` header must list *both*
+`application/json` and `text/event-stream`. Clients do this for you; hand-rolled
+`curl` probes usually do not, and the resulting 406 looks like an auth failure.
+
+**`400` mentioning `tools`.** A name in `?tools=` is not one this deployment
+serves. The error lists the ones that are.
+
+**A tool errors with `code=403 … beta access`.** `image_search` and
+`video_search` are in Beta and enabled per account; the message says how to
+request it.
+
+**Errors name what happened.** A failed call reports which dependency failed
+and why — a timeout, a connection code, an expired token and by how long — plus
+Octen's own `request_id` where the API returned one. Quote that id in a support
+request; it is the one an engineer can look up.
 
 ## Tools
 
@@ -101,6 +264,127 @@ Reference docs:
 
 - Search: [docs.octen.ai/api-reference/search](https://docs.octen.ai/api-reference/search)
 - Extract: [docs.octen.ai/api-reference/extract](https://docs.octen.ai/api-reference/extract)
+
+### Parameters
+
+Transcribed from the schemas each tool publishes — and those are enforced, so an
+out-of-contract value is refused before any call is made, with a message naming
+the field. The limits track the
+[API reference](https://docs.octen.ai/api-reference/search); a test fails if the
+two drift apart.
+
+`image_search` takes **exactly one** of `query`, `image_url` or `image_data`.
+Every tool also accepts `timeout` (seconds) — a client-side deadline, not sent
+to the API.
+
+#### `search`
+
+| Parameter | Type | Required | Limits | Default |
+|---|---|---|---|---|
+| `query` | string | yes | ≤500 chars |  |
+| `topic` | string |  | `general` / `news` | `"general"` |
+| `count` | integer |  | 1–100 | `5` |
+| `include_domains` | array |  | ≤1200 items; each ≤60 |  |
+| `exclude_domains` | array |  | ≤1200 items; each ≤60 |  |
+| `include_text` | array |  | ≤5 items; each ≤30 |  |
+| `exclude_text` | array |  | ≤5 items; each ≤30 |  |
+| `time_basis` | string |  | `auto` / `published` / `crawled` | `"auto"` |
+| `time_range` | string |  | `day` / `week` / `month` / `year` / `d` / `w` / `m` / `y` |  |
+| `start_time` | string |  |  |  |
+| `end_time` | string |  |  |  |
+| `format` | string |  | `text` / `markdown` | `"text"` |
+| `safesearch` | string |  | `off` / `strict` | `"strict"` |
+| `language` | array |  |  | `[]` |
+| `highlight` | object |  | `enable`, `max_tokens` |  |
+| `full_content` | object |  | `enable`, `max_tokens` |  |
+| `include_images` | boolean |  |  | `false` |
+| `timeout` | integer |  | 1–60 |  |
+
+#### `news_search`
+
+| Parameter | Type | Required | Limits | Default |
+|---|---|---|---|---|
+| `query` | string | yes | ≤500 chars |  |
+| `count` | integer |  | 1–100 | `5` |
+| `include_domains` | array |  | ≤1200 items; each ≤60 |  |
+| `exclude_domains` | array |  | ≤1200 items; each ≤60 |  |
+| `include_text` | array |  | ≤5 items; each ≤30 |  |
+| `exclude_text` | array |  | ≤5 items; each ≤30 |  |
+| `time_basis` | string |  | `auto` / `published` / `crawled` | `"auto"` |
+| `time_range` | string |  | `day` / `week` / `month` / `year` / `d` / `w` / `m` / `y` |  |
+| `start_time` | string |  |  |  |
+| `end_time` | string |  |  |  |
+| `format` | string |  | `text` / `markdown` | `"text"` |
+| `safesearch` | string |  | `off` / `strict` | `"strict"` |
+| `language` | array |  |  | `[]` |
+| `highlight` | object |  | `enable`, `max_tokens` |  |
+| `full_content` | object |  | `enable`, `max_tokens` |  |
+| `include_images` | boolean |  |  | `false` |
+| `timeout` | integer |  | 1–60 |  |
+
+#### `broad_search`
+
+| Parameter | Type | Required | Limits | Default |
+|---|---|---|---|---|
+| `query` | string | yes | ≤500 chars |  |
+| `max_queries` | integer |  | 1–30 | `5` |
+| `topic` | string |  | `general` / `news` | `"general"` |
+| `count` | integer |  | 1–100 | `5` |
+| `include_domains` | array |  | ≤1200 items; each ≤60 |  |
+| `exclude_domains` | array |  | ≤1200 items; each ≤60 |  |
+| `include_text` | array |  | ≤5 items; each ≤30 |  |
+| `exclude_text` | array |  | ≤5 items; each ≤30 |  |
+| `time_basis` | string |  | `auto` / `published` / `crawled` | `"auto"` |
+| `time_range` | string |  | `day` / `week` / `month` / `year` / `d` / `w` / `m` / `y` |  |
+| `start_time` | string |  |  |  |
+| `end_time` | string |  |  |  |
+| `format` | string |  | `text` / `markdown` | `"text"` |
+| `safesearch` | string |  | `off` / `strict` | `"strict"` |
+| `language` | array |  |  | `[]` |
+| `highlight` | object |  | `enable`, `max_tokens` |  |
+| `full_content` | object |  | `enable`, `max_tokens` |  |
+| `include_images` | boolean |  |  | `false` |
+| `timeout` | integer |  | 1–300 |  |
+
+#### `extract`
+
+| Parameter | Type | Required | Limits | Default |
+|---|---|---|---|---|
+| `urls` | array | yes | ≤20 items; each ≤2048 |  |
+| `query` | string |  | ≤500 chars |  |
+| `max_age_seconds` | integer |  | 300–31536000 | `86400` |
+| `format` | string |  | `markdown` / `text` | `"markdown"` |
+| `timeout` | integer |  | 1–60 | `30` |
+| `include_images` | boolean |  |  | `false` |
+| `include_videos` | boolean |  |  | `false` |
+| `include_audio` | boolean |  |  | `false` |
+
+#### `image_search`
+
+| Parameter | Type | Required | Limits | Default |
+|---|---|---|---|---|
+| `query` | string |  | ≤500 chars |  |
+| `image_url` | string |  |  |  |
+| `image_data` | string |  | ≤5242880 chars |  |
+| `topic` | string |  | `general` / `design` | `"general"` |
+| `count` | integer |  | 1–10 | `5` |
+| `include_domains` | array |  |  |  |
+| `exclude_domains` | array |  |  |  |
+| `safesearch` | string |  | `off` / `strict` | `"strict"` |
+| `html_snippet` | object |  | `enable`, `max_tokens` |  |
+| `timeout` | integer |  | 1–60 |  |
+
+#### `video_search`
+
+| Parameter | Type | Required | Limits | Default |
+|---|---|---|---|---|
+| `query` | string | yes | ≤500 chars |  |
+| `count` | integer |  | 1–10 | `5` |
+| `time_range` | string |  | `day` / `week` / `month` / `year` / `d` / `w` / `m` / `y` |  |
+| `start_time` | string |  |  |  |
+| `end_time` | string |  |  |  |
+| `safesearch` | string |  | `off` / `strict` | `"strict"` |
+| `timeout` | integer |  | 1–60 |  |
 
 ### Keep the tools always on (optional)
 
@@ -145,6 +429,38 @@ For the full decision tree and integration patterns, see [docs/best-practices.md
 - `Fetch these URLs and only summarize the ones whose category is Finance.`
 - `Search site:docs.anthropic.com prompt caching and return only the relevant highlights.`
 
+## Self-hosting the HTTP server
+
+The hosted endpoint above runs this same code; you can run it yourself instead:
+
+```bash
+PORT=8080 npx -y -p octen-mcp octen-mcp-http   # or: octen-mcp-http after a global install
+```
+
+Endpoints: `POST /mcp` (stateless Streamable HTTP) and `GET /healthz`. Stateless
+by design — there is no session to lose, so scaling is a matter of running more
+copies behind a load balancer. Credentials travel per request and never come
+from the server's own environment: a request without one fails rather than
+quietly spending the host's key.
+
+**Authorization is off unless you configure it.** Set both
+`OCTEN_OAUTH_AUTHORIZATION_SERVER` and `OCTEN_MCP_RESOURCE` and the server
+advertises RFC 9728 protected-resource metadata and answers uncredentialed
+requests with a `401` challenge. Leave them unset and it advertises nothing —
+an instance should never point clients at an authorization server it does not
+have — and a missing key surfaces at call time instead.
+
+**Argument validation.** Each tool's declared `inputSchema` is enforced, not
+just advertised: types, ranges, string lengths, array sizes, enums, required
+parameters, and the property list itself. An out-of-contract call is refused
+with a message naming the field, before anything is sent to the API.
+
+**Sending an image as base64.** `image_search` accepts `image_data` up to 5MB
+encoded, which travels inside the JSON-RPC body. `OCTEN_MCP_MAX_BODY` defaults
+to 6 MiB to make that work unconfigured; `OCTEN_MCP_MAX_INFLIGHT_BODY` (24 MiB)
+separately bounds what all in-flight bodies hold at once, since a per-request
+cap does nothing about many concurrent ones.
+
 ## Environment variables
 
 | Variable | Required | Default | Notes |
@@ -159,6 +475,31 @@ For the full decision tree and integration patterns, see [docs/best-practices.md
 | `OCTEN_RETRY` | no | on | Set to `false`/`0`/`off`/`no` to disable the single automatic retry on connection-level failures. Retries cost quota when the original request had in fact reached the server. |
 | `OCTEN_HTTP2` | no | off | Opt into HTTP/2. Measured no faster for the usual one-request-at-a-time pattern, and not reliable through every CONNECT proxy — worth trying if you issue many tool calls in parallel. |
 | `OCTEN_MCP_DEBUG` | no | off | Request tracing on **stderr** (stdout carries MCP framing). See below. |
+
+### Remote HTTP form only
+
+These are read only by `octen-mcp-http`; the stdio entry ignores them.
+
+| Variable | Required | Default | Notes |
+|---|---|---|---|
+| `PORT` | no | `8080` | `0` picks an ephemeral port. |
+| `OCTEN_MCP_LOG` | no | human text | `json` emits one JSON object per event, for a log pipeline. |
+| `OCTEN_MCP_MAX_BODY` | no | `6291456` | Per-request body cap, in bytes, enforced on bytes received. Over it: `413`. Sized so `image_search`'s `image_data` (5MB encoded) works unconfigured; turn it down if this deployment never sends images. |
+| `OCTEN_MCP_MAX_INFLIGHT_BODY` | no | `25165824` | Ceiling on the total bytes all in-flight bodies hold at once. The per-request cap stops one huge request; this stops many ordinary ones. Over it: `503` + `Retry-After`. Measured: resident cost runs about ten times this, because a base64 body exists two or three times over as a UTF-16 string. |
+| `OCTEN_MCP_BODY_DRAIN_MS` | no | `2000` | After a `413`, how long to keep discarding the rest of the body so the `413` itself gets delivered. |
+| `OCTEN_DRAIN_TIMEOUT_MS` | no | `310000` | On `SIGTERM`, how long in-flight calls may finish. Must stay below the pod's `terminationGracePeriodSeconds`, and above the longest tool budget (`broad_search`, 300s). |
+
+**OAuth.** Off unless both of the first two are set, so an instance never
+advertises an authorization server it does not have.
+
+| Variable | Required | Default | Notes |
+|---|---|---|---|
+| `OCTEN_OAUTH_AUTHORIZATION_SERVER` | for OAuth | — | Authorization server base URL. Compared byte-for-byte against the token's `iss`, and used to build the JWKS URL — **no trailing slash**; the process refuses to start with one, because it would reject every token. |
+| `OCTEN_MCP_RESOURCE` | for OAuth | — | This deployment's public URL, e.g. `https://mcp.example.com/mcp`. Compared byte-for-byte against the token's `aud` (RFC 8707), so a stray trailing slash fails every call. Cannot be inferred behind a proxy, hence explicit. |
+| `OCTEN_OAUTH_RESOLVE_URL` | for OAuth | — | Internal endpoint that exchanges a grant for an API key. Must be reachable privately; a public address will not serve it. |
+| `OCTEN_OAUTH_RESOLVE_TOKEN` | for OAuth | — | Shared secret sent to that endpoint as `X-Octen-Service-Token`. |
+| `OCTEN_OAUTH_RESOLVE_CACHE_TTL_MS` | no | `60000` | How long a resolved grant is reused. This is the revocation-propagation window: a token revoked now keeps working for up to this long. `0` resolves on every call, at the cost of putting that service in front of every tool call. |
+| `OCTEN_JWKS_REFETCH_COOLDOWN_MS` | no | `10000` | Floor between JWKS refetches triggered by an unknown key id. The trigger is an unverified token header, so without a floor each such request becomes one request to the authorization server. Lowering it widens that by the same ratio. |
 
 ### Setting these in Claude Desktop (and where the logs go)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octen-mcp",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octen-mcp",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen \u2014 web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",
@@ -16,7 +16,8 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "octen-mcp": "dist/index.js"
+    "octen-mcp": "dist/index.js",
+    "octen-mcp-http": "dist/httpServer.js"
   },
   "files": [
     "dist",
@@ -25,13 +26,14 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/index.js",
+    "build": "tsc && chmod +x dist/index.js dist/httpServer.js",
     "watch": "tsc --watch",
     "dev": "tsc && node dist/index.js",
     "inspect": "npx -y @modelcontextprotocol/inspector node dist/index.js",
     "pretest": "npm run build",
     "test": "node --test test/*.test.mjs",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "dev:http": "tsc && node dist/httpServer.js"
   },
   "keywords": [
     "mcp",

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -9,7 +9,8 @@
  * None of these are in Firecrawl / Exa / Tavily today.
  */
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
-import { postJson, OctenHttpError, bodyReadFailure } from "./http.js";
+import { postJson, OctenHttpError, bodyReadFailure, missingKeyMessage, type HandlerContext } from "./http.js";
+import { formatMediaList, formatMediaItem } from "./search.js";
 
 const API_KEY = process.env.OCTEN_API_KEY;
 
@@ -38,10 +39,10 @@ keywords: read page, fetch url, scrape, page content, article text, parse webpag
     properties: {
       urls: {
         type: "array",
-        items: { type: "string" },
+        items: { type: "string", maxLength: 2048 },
         minItems: 1,
         maxItems: 20,
-        description: "URLs to extract. 1-20 per call. Bare hosts ok.",
+        description: "URLs to extract. 1-20 per call, each ≤2048 chars. Bare hosts ok.",
       },
       query: {
         type: "string",
@@ -57,6 +58,7 @@ keywords: read page, fetch url, scrape, page content, article text, parse webpag
       max_age_seconds: {
         type: "integer",
         minimum: 300,
+        maximum: 31536000,
         default: 86400,
         description:
           "Maximum age of cached content in seconds. Default 24h. Lower this " +
@@ -95,17 +97,20 @@ interface ExtractArgs {
 }
 
 /** Handler — POSTs to Octen Extract and reshapes the response for the LLM. */
-export async function handleExtract(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+export async function handleExtract(rawArgs: Record<string, unknown>, ctx?: HandlerContext): Promise<CallToolResult> {
   const args = rawArgs as unknown as ExtractArgs;
 
   if (!Array.isArray(args.urls) || args.urls.length === 0) {
     return errorResult("`urls` must be a non-empty array of strings");
   }
-  if (!API_KEY) {
-    return errorResult(
-      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
-      "and add it to your MCP client config (see README)."
-    );
+  // When a transport supplies ctx, it is authoritative — no env fallback. The
+  // stdio entry resolves the env key into ctx itself; falling back here would
+  // let an unauthenticated HTTP caller silently ride the deployment's own
+  // credential. The bare fallback exists only for direct in-process callers
+  // (the unit suites) that invoke handlers without a transport.
+  const apiKey = ctx ? ctx.apiKey : API_KEY;
+  if (!apiKey) {
+    return errorResult(missingKeyMessage(ctx));
   }
 
   // Drop undefined fields so server defaults apply.
@@ -121,6 +126,7 @@ export async function handleExtract(rawArgs: Record<string, unknown>): Promise<C
   let resp: Response;
   try {
     resp = await postJson({
+      apiKey,
       path: "/extract",
       body,
       label: "Octen Extract",
@@ -191,10 +197,13 @@ function formatResult(r: any, idx: number, total: number): string {
   if (r.time_published) lines.push(`**Published:** ${r.time_published}`);
   if (r.time_last_crawled) lines.push(`**Last crawled:** ${r.time_last_crawled}`);
   if (r.favicon) lines.push(`**Favicon:** ${r.favicon}`);
-  if (r.cover_image?.url) lines.push(`**Cover image:** ${r.cover_image.url}`);
-  if (Array.isArray(r.images) && r.images.length) lines.push(`**Images:** ${r.images.length}`);
-  if (Array.isArray(r.videos) && r.videos.length) lines.push(`**Videos:** ${r.videos.length}`);
-  if (Array.isArray(r.audio)  && r.audio.length)  lines.push(`**Audio:** ${r.audio.length}`);
+  if (r.cover_image?.url) lines.push(`**Cover image:** ${formatMediaItem(r.cover_image)}`);
+  // Same renderer as search, imported rather than reimplemented: this whole
+  // defect began as two copies of the media block drifting apart — the copy
+  // here handled `cover_image` correctly while the one in search did not.
+  lines.push(...formatMediaList("Images", r.images));
+  lines.push(...formatMediaList("Videos", r.videos));
+  lines.push(...formatMediaList("Audio", r.audio));
 
   // Content body: highlights (if query supplied) take precedence, else full_content.
   if (Array.isArray(r.highlights) && r.highlights.length) {

--- a/src/http.ts
+++ b/src/http.ts
@@ -41,12 +41,24 @@ import { fetch as undiciFetch, Agent, EnvHttpProxyAgent, type Dispatcher } from 
 import { randomUUID } from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
 
-/** Read a positive-integer env override, falling back when unset/invalid. */
-function envInt(name: string, fallback: number): number {
+/**
+ * Read an integer env override, falling back when unset or unusable.
+ *
+ * The fallback on garbage is the whole point: a bare `Number(env)` yields NaN,
+ * and NaN silently disables whatever it configures — every comparison against
+ * it is false, so a size cap stops capping and a deadline is never reached.
+ * That failure is invisible until the moment the limit was supposed to save
+ * you, so it must not be reachable by typo.
+ *
+ * `min` exists because 0 is meaningful for some settings and catastrophic for
+ * others: `PORT=0` legitimately means "pick an ephemeral port", while a
+ * timeout of 0 would be a broken config dressed up as a valid one.
+ */
+export function envInt(name: string, fallback: number, min = 1): number {
   const raw = process.env[name];
   if (raw === undefined || raw.trim() === "") return fallback;
   const n = Number(raw);
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+  return Number.isFinite(n) && n >= min ? Math.floor(n) : fallback;
 }
 
 const FALSEY = ["false", "0", "off", "no"];
@@ -73,8 +85,36 @@ export const DEBUG = envFlag("OCTEN_MCP_DEBUG");
  * times, and a duration without an absolute time cannot be aligned with
  * anything.
  */
+/**
+ * `OCTEN_MCP_LOG=json` — structured JSON lines, for a hosted deployment's log
+ * pipeline. Off by default so stdio installs keep the human-readable format.
+ */
+const LOG_JSON = (process.env.OCTEN_MCP_LOG ?? "").trim().toLowerCase() === "json";
+
+/** Whether any tracing is emitted: debug mode (human text) or hosted mode (JSON). */
+export const LOGGING = DEBUG || LOG_JSON;
+
+/**
+ * One trace event, rendered per mode: a JSON line under `OCTEN_MCP_LOG=json`,
+ * the established human-readable line otherwise. Fields with `undefined`
+ * values are dropped so JSON lines stay dense. The API key must never appear
+ * in `fields` — only its 8-char prefix (CI asserts this).
+ */
+export function logEvent(event: string, fields: Record<string, unknown>, text?: string): void {
+  if (!LOGGING) return;
+  if (LOG_JSON) {
+    const clean: Record<string, unknown> = { ts: new Date().toISOString(), event };
+    for (const [k, v] of Object.entries(fields)) if (v !== undefined) clean[k] = v;
+    process.stderr.write(JSON.stringify(clean) + "\n");
+  } else {
+    process.stderr.write(
+      `[octen-mcp ${new Date().toISOString()}] ${text ?? `${event} ${JSON.stringify(fields)}`}\n`
+    );
+  }
+}
+
 export function debug(msg: string): void {
-  if (DEBUG) process.stderr.write(`[octen-mcp ${new Date().toISOString()}] ${msg}\n`);
+  logEvent("debug", { msg }, msg);
 }
 
 /**
@@ -86,8 +126,8 @@ export function debug(msg: string): void {
  * call took 900ms but not that 640ms of it was a TLS handshake we should not
  * have needed.
  *
- * Subscriptions are installed only under OCTEN_MCP_DEBUG so the normal path
- * carries no cost.
+ * Subscriptions are installed only when tracing is on (debug or hosted JSON
+ * mode) so the untraced path carries no cost.
  */
 /** Per-call connection bookkeeping. See {@link connectTrace}. */
 interface CallTrace {
@@ -135,7 +175,7 @@ function socketKind(): string {
 /** Monotonic label for connections, purely so log lines can be told apart. */
 let connectSeq = 0;
 
-if (DEBUG) {
+if (LOGGING) {
   const dc = await import("node:diagnostics_channel");
   dc.channel("undici:client:beforeConnect").subscribe(() => {
     const t = connectTrace.getStore();
@@ -146,31 +186,31 @@ if (DEBUG) {
     if (t) t.established++;
     const host = evt?.connectParams?.host ?? "?";
     const s = evt?.socket;
-    debug(
-      `connect #${++connectSeq} established to ${host}` +
-      (t?.startedAt ? ` in ${Date.now() - t.startedAt}ms` : "") +
-      // The peer address is the field that matters most when the origin is
-      // anycast: api.octen.ai resolves to whichever edge is nearest the
-      // client, so "which edge did this machine actually reach" is not
-      // answerable from the hostname, and an edge-local problem is invisible
-      // without it.
-      (s?.remoteAddress ? ` peer=${s.remoteAddress}:${s.remotePort}` : "") +
-      (s?.getProtocol?.() ? ` tls=${s.getProtocol()}` : "") +
-      (s?.alpnProtocol ? ` alpn=${s.alpnProtocol}` : "")
-    );
+    const seq = ++connectSeq;
+    const connect_ms = t?.startedAt ? Date.now() - t.startedAt : undefined;
+    // The peer address is the field that matters most when the origin is
+    // anycast: api.octen.ai resolves to whichever edge is nearest the client,
+    // so "which edge did this machine actually reach" is not answerable from
+    // the hostname, and an edge-local problem is invisible without it.
+    const peer = s?.remoteAddress ? `${s.remoteAddress}:${s.remotePort}` : undefined;
+    const tls = s?.getProtocol?.() || undefined;
+    const alpn = s?.alpnProtocol || undefined;
+    logEvent("connect", { seq, host, connect_ms, peer, tls, alpn },
+      `connect #${seq} established to ${host}` +
+      (connect_ms !== undefined ? ` in ${connect_ms}ms` : "") +
+      (peer ? ` peer=${peer}` : "") + (tls ? ` tls=${tls}` : "") + (alpn ? ` alpn=${alpn}` : ""));
   });
   dc.channel("undici:client:connectError").subscribe((evt: any) => {
     const t = connectTrace.getStore();
     const err = evt?.error;
     const p = evt?.connectParams;
-    debug(
-      `connect FAILED` +
-      (t?.startedAt ? ` after ${Date.now() - t.startedAt}ms` : "") +
-      ` code=${err?.code ?? err?.name ?? "?"} ` +
-      `host=${p?.hostname ?? "?"}` +
-      (err?.address ? ` peer=${err.address}${err.port ? ":" + err.port : ""}` : "") +
-      ` ${err?.message ?? ""}`
-    );
+    const connect_ms = t?.startedAt ? Date.now() - t.startedAt : undefined;
+    const code = err?.code ?? err?.name ?? "?";
+    const host = p?.hostname ?? "?";
+    const peer = err?.address ? `${err.address}${err.port ? ":" + err.port : ""}` : undefined;
+    logEvent("connect_failed", { connect_ms, code, host, peer, msg: err?.message },
+      `connect FAILED` + (connect_ms !== undefined ? ` after ${connect_ms}ms` : "") +
+      ` code=${code} host=${host}` + (peer ? ` peer=${peer}` : "") + ` ${err?.message ?? ""}`);
   });
 }
 
@@ -246,7 +286,15 @@ function buildDispatcher(): Dispatcher {
   }
 }
 
-const dispatcher: Dispatcher = buildDispatcher();
+/**
+ * Exported so every outbound call in this process shares it — including the
+ * OAuth side's JWKS and resolve-key calls. A `fetch` without it falls back to
+ * undici's global dispatcher, which is precisely the untuned configuration
+ * this module was written to escape: proxy environment ignored, 4s keep-alive.
+ * A second, differently-configured HTTP path is how "the proxy fix" ends up
+ * covering only some of the requests.
+ */
+export const dispatcher: Dispatcher = buildDispatcher();
 
 /**
  * Test seam only. The suite scripts outcomes (a scripted ECONNRESET, a
@@ -261,11 +309,15 @@ export function _setFetchForTests(f?: typeof undiciFetch): void {
   fetchImpl = f ?? undiciFetch;
 }
 
-debug(
+logEvent("startup", {
+  dispatcher: proxyConfigured ? "EnvHttpProxyAgent" : "Agent",
+  keepalive_ms: agentOptions.keepAliveTimeout,
+  connect_timeout_ms: agentOptions.connectTimeout,
+  h2: agentOptions.allowH2,
+},
   `dispatcher=${proxyConfigured ? "EnvHttpProxyAgent" : "Agent"} ` +
   `keepAlive=${agentOptions.keepAliveTimeout}ms connect=${agentOptions.connectTimeout}ms ` +
-  `h2=${agentOptions.allowH2}`
-);
+  `h2=${agentOptions.allowH2}`);
 
 /**
  * Failures worth one retry.
@@ -337,6 +389,14 @@ export interface PostJsonOptions {
   /** Applied when the caller passes no timeout. */
   defaultTimeoutSec: number;
   /**
+   * Credential for this call. Comes from the process environment under stdio,
+   * and from the request headers under the HTTP transport, where one process
+   * serves many keys — which is why it travels per call rather than living at
+   * module level. Callers verify presence before calling; this layer only
+   * forwards it.
+   */
+  apiKey: string;
+  /**
    * Whether raising `timeout` would actually buy more headroom. False when the
    * effective value already sits at the schema maximum — `broad_search`
    * defaults to 60s and cannot go higher — so we don't advise an agent to turn
@@ -386,6 +446,30 @@ export function bodyReadFailure(label: string, resp: Response, e: unknown): stri
   return `${label} returned non-JSON (HTTP ${resp.status})`;
 }
 
+/**
+ * Per-invocation context handed to tool handlers by the transport layer.
+ *
+ * Under stdio there is one user and the key lives in the environment, so this
+ * is absent. Under the HTTP transport one process serves many keys, so the
+ * credential must travel with the call — reading it from module state would
+ * hand one tenant's key to another's request.
+ */
+export interface HandlerContext {
+  apiKey?: string;
+  /** Only used to word the missing-key error usefully for the caller's setup. */
+  transport?: "stdio" | "http";
+}
+
+/** The missing-key error, phrased for how this particular caller would fix it. */
+export function missingKeyMessage(ctx?: HandlerContext): string {
+  return ctx?.transport === "http"
+    ? "No API key on this request. Send it in the `x-api-key` header (or " +
+      "`Authorization: Bearer <key>`, or the `octenApiKey` query parameter). " +
+      "Get a key at https://octen.ai."
+    : "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
+      "and add it to your MCP client config (see README).";
+}
+
 /** Thrown by {@link postJson}; `message` is already formatted for the LLM. */
 export class OctenHttpError extends Error {}
 
@@ -405,8 +489,7 @@ export function postJson(opts: PostJsonOptions): Promise<Response> {
 }
 
 async function postJsonInner(opts: PostJsonOptions): Promise<Response> {
-  const { path, body, label, timeoutSec, defaultTimeoutSec, canRaiseTimeout = true } = opts;
-  const apiKey = process.env.OCTEN_API_KEY!;
+  const { path, body, label, timeoutSec, defaultTimeoutSec, canRaiseTimeout = true, apiKey } = opts;
   const effectiveTimeoutSec = timeoutSec ?? defaultTimeoutSec;
   // One correlation id for the whole logical call, retry included, so a support
   // ticket maps to every attempt in the server logs.
@@ -447,15 +530,15 @@ async function postJsonInner(opts: PostJsonOptions): Promise<Response> {
         signal: deadline,
         dispatcher,
       })) as unknown as Response;
-      if (DEBUG) {
-        debug(
-          `${path} attempt=${attempt} status=${resp.status} ` +
-          `elapsed=${Date.now() - started}ms ` +
-          // Whether this call paid for a handshake is the difference between
-          // "the service is slow" and "we threw the connection away".
-          `socket=${socketKind()} ` +
-          `request_id=${requestId}`
-        );
+      if (LOGGING) {
+        const elapsed_ms = Date.now() - started;
+        // Whether this call paid for a handshake is the difference between
+        // "the service is slow" and "we threw the connection away".
+        const socket = socketKind();
+        logEvent("request",
+          { path, attempt, status: resp.status, elapsed_ms, socket, request_id: requestId },
+          `${path} attempt=${attempt} status=${resp.status} elapsed=${elapsed_ms}ms ` +
+          `socket=${socket} request_id=${requestId}`);
       }
       return resp;
     } catch (e) {
@@ -463,10 +546,9 @@ async function postJsonInner(opts: PostJsonOptions): Promise<Response> {
       const err = e as Error;
 
       if (err.name === "TimeoutError" || err.name === "AbortError") {
-        debug(
-          `${path} attempt=${attempt} TIMEOUT after ${elapsed}ms ` +
-          `socket=${socketKind()} request_id=${requestId}`
-        );
+        logEvent("request_timeout",
+          { path, attempt, elapsed_ms: elapsed, socket: socketKind(), request_id: requestId },
+          `${path} attempt=${attempt} TIMEOUT after ${elapsed}ms socket=${socketKind()} request_id=${requestId}`);
         throw new OctenHttpError(
           // No id here: nothing reached the server, so there is nothing the
           // other side could look up — and a client-generated id labelled
@@ -484,14 +566,12 @@ async function postJsonInner(opts: PostJsonOptions): Promise<Response> {
 
       const { code, detail } = describeError(e);
       lastDetail = detail;
-      debug(
-        // `socket=` on the failure path too, not just on success: a reused
-        // socket that fails is a stale keep-alive connection, a new one that
-        // fails is the network refusing us. Same error code, different owner.
-        `${path} attempt=${attempt} FAILED after ${elapsed}ms ` +
-        `socket=${socketKind()} ` +
-        `${detail} request_id=${requestId}`
-      );
+      // `socket=` on the failure path too, not just on success: a reused
+      // socket that fails is a stale keep-alive connection, a new one that
+      // fails is the network refusing us. Same error code, different owner.
+      logEvent("request_failed",
+        { path, attempt, elapsed_ms: elapsed, socket: socketKind(), code, detail, request_id: requestId },
+        `${path} attempt=${attempt} FAILED after ${elapsed}ms socket=${socketKind()} ${detail} request_id=${requestId}`);
 
       if (attempt === 1 && RETRYABLE_CODES.has(code)) {
         // Only retry if the shared deadline can still accommodate one. Sleeping
@@ -504,7 +584,8 @@ async function postJsonInner(opts: PostJsonOptions): Promise<Response> {
           await new Promise((r) => setTimeout(r, RETRY_BACKOFF_MS));
           continue;
         }
-        debug(`${path} not retrying: only ${remaining}ms of budget left request_id=${requestId}`);
+        logEvent("retry_skipped", { path, remaining_ms: remaining, request_id: requestId },
+          `${path} not retrying: only ${remaining}ms of budget left request_id=${requestId}`);
       }
 
       throw new OctenHttpError(

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -1,0 +1,853 @@
+#!/usr/bin/env node
+/**
+ * Octen MCP server — remote HTTP entry (Streamable HTTP transport).
+ *
+ * Shape of the deployment:
+ *
+ *  - **Stateless.** All six tools are single-shot; there is no session state
+ *    worth holding, and statelessness makes horizontal scaling a matter of
+ *    adding instances. Concretely: a fresh Server + transport pair per POST,
+ *    with `sessionIdGenerator: undefined`, torn down when the response closes.
+ *    No `Mcp-Session-Id` is issued; revisit only if a real client needs one.
+ *  - **Where auth is enforced depends on whether there is an authorization
+ *    server.** With one configured, an uncredentialed request is answered 401
+ *    + `WWW-Authenticate` on every method — that challenge is the only trigger
+ *    MCP clients act on, and without it a client concludes the server needs no
+ *    authorization and never offers to log in. Without one, there is nowhere
+ *    to send anybody, so `initialize` and `tools/list` stay open and a missing
+ *    key fails at call time with an error that says what to fix.
+ *  - **Three credential spellings**, in this order: `x-api-key: <key>`,
+ *    `Authorization: Bearer <key>` (some clients can only send that one), and
+ *    an `octenApiKey` query parameter for clients that can be given nothing
+ *    but a URL.
+ *  - **`?tools=a,b`** narrows the roster for one connection, because a client
+ *    loads every advertised tool's schema into the model's context.
+ *
+ * The key is bound per request via a closure handed to `createOctenServer` —
+ * one process serves many tenants, so the credential must travel with the
+ * call, never through module state.
+ *
+ * Built to run as a Kubernetes Deployment: liveness/readiness both probe
+ * `/healthz`, which flips to 503 the moment SIGTERM arrives so the pod is
+ * pulled from endpoints while in-flight requests drain. The pod spec must set
+ * `terminationGracePeriodSeconds` above the longest tool budget (300s for
+ * `broad_search`) or rolling deploys will kill live calls. Reference manifests
+ * live with the deployment spec (the infra repo owns the real ones — they are
+ * deliberately not in this public repo).
+ */
+import http from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+import { createOctenServer, VERSION, AVAILABLE_TOOL_NAMES, KNOWN_TOOL_NAMES } from "./server.js";
+import { logEvent, envInt } from "./http.js";
+import {
+  looksLikeAccessToken, apiKeyFromAccessToken,
+  TokenInvalidError, OAuthBackendError, type OAuthRsConfig,
+} from "./oauthRs.js";
+
+// 0 is legal and means "ephemeral port" — the test harness relies on it.
+const PORT = envInt("PORT", 8080, 0);
+
+/**
+ * OAuth surface — OFF unless both are configured, so a self-hosted instance
+ * without an authorization server advertises nothing it cannot honour:
+ *
+ *  - OCTEN_OAUTH_AUTHORIZATION_SERVER: the AS base URL (https://auth.octen.ai)
+ *  - OCTEN_MCP_RESOURCE: this deployment's public resource URL
+ *    (https://mcp.octen.ai/mcp). Cannot be derived behind a fronting proxy,
+ *    and RFC 8707 aud-binding demands it byte-for-byte, so it is explicit.
+ *
+ * When on: the RFC 9728 protected-resource metadata is served (both the bare
+ * and the path-derived well-known, matching what real clients fetch), and any
+ * uncredentialed request is answered with the 401 challenge that makes clients
+ * start OAuth at all — without a 401 + `WWW-Authenticate`, a client treats the
+ * server as unauthenticated and the user never sees a consent screen.
+ * `/mcp/oauth` and `?login` force that challenge even when a credential is
+ * present, which is the only route from an already-configured API key to OAuth.
+ */
+const AUTH_SERVER = (process.env.OCTEN_OAUTH_AUTHORIZATION_SERVER ?? "").trim();
+const RESOURCE = (process.env.OCTEN_MCP_RESOURCE ?? "").trim();
+const OAUTH_ENABLED = AUTH_SERVER !== "" && RESOURCE !== "";
+
+// The grant→key exchange needs the internal resolve endpoint and its service
+// token (spec §I2). Without them, JWT-shaped credentials are rejected 503
+// rather than silently forwarded upstream as if they were API keys.
+const RS_CONFIG: OAuthRsConfig = {
+  authorizationServer: AUTH_SERVER,
+  resource: RESOURCE,
+  resolveUrl: (process.env.OCTEN_OAUTH_RESOLVE_URL ?? "").trim() || undefined,
+  resolveToken: (process.env.OCTEN_OAUTH_RESOLVE_TOKEN ?? "").trim() || undefined,
+};
+
+/**
+ * Both URLs are parsed at startup, not on first use.
+ *
+ * Deferring it meant a bad value passed every startup check — the process
+ * listened, `/healthz` answered 200, so Kubernetes kept the pod in rotation —
+ * and then threw out of the request handler on the first `?login`, killing the
+ * process. A pod that is healthy until someone uses it is the worst shape this
+ * can fail in, so an unusable value stops the process here, where the log line
+ * is the first thing an operator sees.
+ */
+function requireUrl(name: string, raw: string): URL {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    console.error(`[octen-mcp] ${name} is not a valid absolute URL: ${JSON.stringify(raw)}`);
+    process.exit(1);
+  }
+  if (u.protocol !== "https:" && u.protocol !== "http:") {
+    console.error(`[octen-mcp] ${name} must be http(s), got ${JSON.stringify(raw)}`);
+    process.exit(1);
+  }
+  return u;
+}
+
+const RESOURCE_URL = OAUTH_ENABLED ? requireUrl("OCTEN_MCP_RESOURCE", RESOURCE) : undefined;
+if (OAUTH_ENABLED) {
+  requireUrl("OCTEN_OAUTH_AUTHORIZATION_SERVER", AUTH_SERVER);
+  // A trailing slash here is a 100% outage that looks like every user's token
+  // being bad. The value is used two ways and breaks both: the JWKS URL
+  // becomes `…//api/oauth/jwks`, and `iss` is compared byte-for-byte against a
+  // value the authorization server never emits with a trailing slash — so
+  // every token is refused. Measured. The rejection message does print both
+  // strings, but they differ by the one character nobody sees, so this is
+  // worth refusing at startup rather than explaining afterwards.
+  if (AUTH_SERVER.endsWith("/")) {
+    console.error(
+      `[octen-mcp] OCTEN_OAUTH_AUTHORIZATION_SERVER must not end with "/" — ` +
+      `got ${JSON.stringify(AUTH_SERVER)}. It is compared byte-for-byte against the ` +
+      `\`iss\` claim and used to build the JWKS URL; a trailing slash breaks both.`);
+    process.exit(1);
+  }
+}
+
+/**
+ * RFC 9728 path-derived form: the well-known prefix followed by the resource's
+ * own path. Derived rather than hardcoded to `/mcp` — a self-hosted instance
+ * mounted elsewhere would otherwise advertise a document at a path it does not
+ * serve, and clients that follow the challenge would 404 into a dead end.
+ */
+const PRM_PATH = RESOURCE_URL
+  ? `/.well-known/oauth-protected-resource${RESOURCE_URL.pathname === "/" ? "" : RESOURCE_URL.pathname}`
+  : "";
+const PRM_URL = RESOURCE_URL ? `${RESOURCE_URL.origin}${PRM_PATH}` : "";
+
+function prmDocument(): unknown {
+  return {
+    resource: RESOURCE,
+    authorization_servers: [AUTH_SERVER],
+    scopes_supported: ["mcp:tools"],
+    bearer_methods_supported: ["header"],
+  };
+}
+
+/**
+ * RFC 6750 §3 quoted-string charset for `error_description`: printable ASCII
+ * minus `"` and `\`. The values passed through here are partly derived from an
+ * unverified token, and a CRLF reaching `res.writeHead` throws
+ * `ERR_INVALID_CHAR` out of the request handler — an unauthenticated remote
+ * kill. {@link safeKid} already scrubs the one field known to carry attacker
+ * text; this is the layer that holds when the next such field is added without
+ * anyone remembering why the first one was scrubbed.
+ */
+function headerSafe(s: string): string {
+  return s.replace(/[^\x20-\x21\x23-\x5b\x5d-\x7e]/g, " ").slice(0, 200);
+}
+
+/**
+ * Requests larger than this are refused before the transport parses them.
+ *
+ * 6 MiB, sized so `image_search`'s `image_data` works without configuration:
+ * the API caps that at 5 MiB encoded, and the JSON-RPC envelope around it is
+ * negligible, so this leaves headroom without inviting much else. A default
+ * below the largest argument a tool accepts would mean the tool is advertised
+ * and unusable over this transport — the client sees a 413 with no obvious
+ * connection to the picture it tried to send.
+ *
+ * It is a real cost: an in-flight request may now hold 6 MiB rather than 1,
+ * and the credential check runs before the body is read, so reaching it takes
+ * a valid key. Deployments that never send images can and should turn this
+ * back down.
+ */
+const MAX_BODY_BYTES = envInt("OCTEN_MCP_MAX_BODY", 6 * 1024 * 1024);
+
+class BodyTooLargeError extends Error {}
+/** Thrown when the *sum* of bodies in flight would exceed the budget → 503. */
+class BodyBudgetExceededError extends Error {}
+
+/**
+ * Ceiling on the total bytes all in-flight request bodies may hold at once.
+ *
+ * The per-request cap stops one enormous request; it does nothing about many
+ * ordinary ones. With the per-request cap at 6 MiB, forty concurrent bodies
+ * measured 772 MB resident against a 768 MiB container limit — an OOM kill
+ * reachable by anyone holding a key, with no single request breaking a rule.
+ *
+ * 24 MiB, not because that is a lot of bytes but because of what each byte
+ * costs once it is in the process: a 5 MB ASCII body is ~10 MB as a UTF-16 JS
+ * string, and it exists two or three times over — the concatenated body, the
+ * parsed argument, the outgoing request. Measured, the resident cost runs
+ * about ten times the budget, so 24 MiB is what fits a 768 MiB container with
+ * room to work. It still allows several largest-case images at once, far more
+ * concurrent image search than a real deployment does.
+ * Over it, the newest request is refused 503 + Retry-After: this is capacity,
+ * not a malformed call, and the caller should come back rather than change
+ * anything.
+ */
+const MAX_INFLIGHT_BODY_BYTES = envInt("OCTEN_MCP_MAX_INFLIGHT_BODY", 24 * 1024 * 1024);
+let inflightBodyBytes = 0;
+
+/**
+ * How long we keep draining an over-sized request after answering 413, so the
+ * answer survives the close. See the drain block for why hanging up
+ * immediately loses the response.
+ */
+const BODY_DRAIN_MS = envInt("OCTEN_MCP_BODY_DRAIN_MS", 2_000);
+
+/**
+ * Read the body with the cap enforced on bytes actually received.
+ *
+ * Checking `Content-Length` alone is not a cap, it is a cap against clients
+ * that volunteer their size. A chunked request declares no length, so the
+ * check passed and the transport buffered whatever arrived — measured at 75 MB
+ * accepted against a 1 MiB cap, on an endpoint that needs no credential to
+ * reach and a container limited to 512 MiB. Metering the stream is the only
+ * version of this check that holds.
+ *
+ * The parsed value is handed to the transport (which accepts a pre-parsed
+ * body) rather than letting it read the stream again, because there is no way
+ * to meter a stream someone else is consuming.
+ */
+/**
+ * A request's claim on {@link inflightBodyBytes}, released once — by whoever
+ * gets there first.
+ *
+ * The charge has to outlive the read. An earlier version released it the
+ * moment the body finished arriving, which accounted for the wrong window
+ * entirely: the string is still held while it is parsed, dispatched, and sent
+ * upstream, so the budget was measuring a few milliseconds of each request's
+ * several seconds. Forty concurrent 5 MB bodies still reached 1022 MB with it
+ * in place.
+ */
+interface BodyCharge { bytes: number; release(): void }
+
+function newBodyCharge(): BodyCharge {
+  return {
+    bytes: 0,
+    release() { inflightBodyBytes -= this.bytes; this.bytes = 0; },
+  };
+}
+
+function readBody(req: IncomingMessage, limit: number, charge: BodyCharge): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let done = false;
+    // Failures release here; success hands the charge to the caller, which
+    // holds it until the response closes.
+    const settle = (fn: () => void, releaseNow: boolean) => {
+      if (done) return;
+      done = true;
+      if (releaseNow) charge.release();
+      fn();
+    };
+    req.on("data", (c: Buffer) => {
+      if (done) return;
+      size += c.length;
+      if (size > limit) {
+        settle(() => reject(new BodyTooLargeError(`body exceeded ${limit} bytes`)), true);
+        return;
+      }
+      inflightBodyBytes += c.length;
+      charge.bytes += c.length;
+      if (inflightBodyBytes > MAX_INFLIGHT_BODY_BYTES) {
+        settle(() => reject(new BodyBudgetExceededError(
+          `in-flight request bodies would exceed ${MAX_INFLIGHT_BODY_BYTES} bytes`)), true);
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on("end", () => settle(() => resolve(Buffer.concat(chunks).toString("utf8")), false));
+    req.on("error", (e) => settle(() => reject(e), true));
+    req.on("aborted", () => settle(() => reject(new Error("client aborted the request")), true));
+  });
+}
+
+/**
+ * How long to wait for in-flight requests after SIGTERM. Default covers the
+ * longest tool budget (broad_search 300s) with a margin; the pod's
+ * terminationGracePeriodSeconds must exceed it or Kubernetes wins the race.
+ */
+const DRAIN_TIMEOUT_MS = envInt("OCTEN_DRAIN_TIMEOUT_MS", 310_000);
+
+/**
+ * Query-string spellings accepted as a credential.
+ *
+ * Exactly one, deliberately. Accepting alternative spellings to make somebody
+ * else's config paste in unchanged buys nothing — nobody configuring this
+ * server goes looking for a name it does not document — and every extra name
+ * is one more string on our public interface that docs have to explain and a
+ * packet capture will show.
+ *
+ * This has nothing to do with logging: redactUrl masks values and keeps
+ * parameter names, and only fires on crash paths. A client that sends an
+ * unrecognised spelling still puts it in a crash log; what appears there
+ * depends on what the client sent, not on what we accept.
+ */
+const QUERY_KEY_PARAMS = ["octenApiKey"];
+
+/**
+ * Replace every query-string *value* with a placeholder.
+ *
+ * Whole value, never a prefix: a truncated credential still hands out a usable
+ * head start, and printing it truncated reads as though it had been made safe.
+ * Every parameter is redacted rather than a known list of key names, so a
+ * parameter added later is redacted before anyone remembers to add it here.
+ */
+export function redactUrl(url: string): string {
+  const q = url.indexOf("?");
+  if (q === -1) return url;
+  const path = url.slice(0, q);
+  const names: string[] = [];
+  for (const [k] of new URLSearchParams(url.slice(q + 1))) names.push(`${k}=<redacted>`);
+  return names.length ? `${path}?${names.join("&")}` : path;
+}
+
+/**
+ * Extract the API key: `x-api-key`, then `Authorization: Bearer`, then the
+ * query string.
+ *
+ * The query fallback is last on purpose — any client that can set a header
+ * should keep using one. It exists for clients that can only be handed a URL,
+ * e.g. a hosted-connector UI whose only input field is the endpoint.
+ *
+ * It is **not** needed for Claude Desktop: that config spawns `mcp-remote`,
+ * which does take headers — `--header Name:Value`, and `--header-file <path>`
+ * to keep the credential out of the process arguments (verified against
+ * mcp-remote 0.6.0; an earlier version of this comment claimed it had "no
+ * header option", which was simply wrong). Prefer `--header-file` there.
+ *
+ * A key in a URL is exposed to proxy logs, browser history and Referer headers
+ * — none of which we control. What we do control is our own logs, which is why
+ * {@link redactUrl} exists and why nothing here logs `req.url` raw.
+ */
+function apiKeyFrom(req: IncomingMessage): string | undefined {
+  const direct = req.headers["x-api-key"];
+  if (typeof direct === "string" && direct.trim() !== "") return direct.trim();
+  const auth = req.headers["authorization"];
+  if (typeof auth === "string" && /^bearer\s+/i.test(auth)) {
+    const token = auth.replace(/^bearer\s+/i, "").trim();
+    if (token !== "") return token;
+  }
+  const query = queryOf(req);
+  for (const name of QUERY_KEY_PARAMS) {
+    const v = query.get(name);
+    if (typeof v === "string" && v.trim() !== "") return v.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Read `?tools=a,b` into a validated selection.
+ *
+ * Unknown names are an error rather than a silent skip, and so is a selection
+ * that leaves nothing. Both alternatives fail the same miserable way: the
+ * connection comes up looking fine and a tool the caller asked for simply is
+ * not there, which sends whoever debugs it looking at the tool rather than at
+ * the spelling in their URL. A 400 that names the bad entry and lists the real
+ * ones ends that in one round trip.
+ *
+ * Beta tools that are switched off are absent from `AVAILABLE_TOOL_NAMES`, so
+ * naming one reads exactly like naming a tool that does not exist — a
+ * selection cannot be used to re-enable them.
+ */
+function parseToolSelection(query: URLSearchParams): { tools?: readonly string[] } | { error: string } {
+  const raw = query.get("tools");
+  // Absent, or present-but-empty (`?tools=`): no selection, serve everything.
+  if (raw === null || raw.trim() === "") return {};
+
+  const asked = raw.split(",").map((s) => s.trim()).filter((s) => s !== "");
+  const rejected = asked.filter((n) => !AVAILABLE_TOOL_NAMES.includes(n));
+  if (rejected.length > 0) {
+    // Both are refused, but not for the same reason, and saying so is the
+    // whole point: a real tool name that this deployment does not serve is not
+    // a typo, and calling it "unknown" sends the reader hunting for one that
+    // is not there.
+    const notHere = rejected.filter((n) => KNOWN_TOOL_NAMES.includes(n));
+    const notReal = rejected.filter((n) => !KNOWN_TOOL_NAMES.includes(n));
+    const list = (ns: string[]) => ns.map((n) => JSON.stringify(n)).join(", ");
+    const parts: string[] = [];
+    if (notReal.length > 0) {
+      parts.push(`Unknown tool name${notReal.length > 1 ? "s" : ""}: ${list(notReal)}.`);
+    }
+    if (notHere.length > 0) {
+      parts.push(
+        `${list(notHere)} ${notHere.length > 1 ? "are" : "is"} not enabled on this deployment ` +
+        `(Beta tools are off via OCTEN_ENABLE_BETA_TOOLS).`);
+    }
+    return { error: `${parts.join(" ")} Available: ${AVAILABLE_TOOL_NAMES.join(", ")}.` };
+  }
+  if (asked.length === 0) {
+    return { error: `\`tools\` selected nothing. Available: ${AVAILABLE_TOOL_NAMES.join(", ")}.` };
+  }
+  // Deduplicated so `?tools=search,search` cannot advertise a tool twice.
+  return { tools: [...new Set(asked)] };
+}
+
+/**
+ * The logged fingerprint of a credential: enough to tell two keys apart in a
+ * trace, never enough to be one.
+ *
+ * A flat 8-character prefix — what this used to be — is the whole credential
+ * for anything shorter than that, and the query-string form makes short
+ * hand-typed values more likely to turn up. Measured: a 7-character key
+ * appeared in the log in full. Half the value, capped at 8, keeps traces
+ * distinguishable without that edge.
+ */
+function keyFingerprint(key: string): string {
+  return key.slice(0, Math.min(8, Math.floor(key.length / 2))) + "…";
+}
+
+/** Parse the request's query string. Never throws: `req.url` is attacker input. */
+function queryOf(req: IncomingMessage): URLSearchParams {
+  const raw = req.url ?? "";
+  const q = raw.indexOf("?");
+  return new URLSearchParams(q === -1 ? "" : raw.slice(q + 1));
+}
+
+// The header set hosted MCP endpoints advertise, so a browser-based client
+// written against any of them works here unchanged.
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Accept, Content-Type, Authorization, x-api-key, Mcp-Session-Id, MCP-Protocol-Version, Last-Event-ID",
+  "Access-Control-Expose-Headers": "Mcp-Session-Id",
+};
+
+function json(res: ServerResponse, status: number, body: unknown, extra?: Record<string, string>): void {
+  res.writeHead(status, { "Content-Type": "application/json", ...extra });
+  res.end(JSON.stringify(body));
+}
+
+// ---- Drain state -----------------------------------------------------------
+//
+// On SIGTERM: healthz flips to 503 (readiness pulls the pod from endpoints),
+// new MCP requests are answered 503 + Retry-After — the listener stays open so
+// a client racing endpoint removal gets a retryable answer instead of a TCP
+// reset — and the process exits once in-flight work finishes or the drain
+// budget runs out. A second signal exits immediately —
+// that is the ctrl-c-twice escape hatch in local runs.
+let draining = false;
+let inFlight = 0;
+
+/**
+ * `http.createServer` does not await its handler, so a rejection escaping an
+ * async one is an unhandled rejection — which Node turns into process exit by
+ * default. That makes every un-caught throw anywhere in request handling a
+ * whole-server outage rather than one failed request, and the throws reachable
+ * from unauthenticated input are exactly the ones an attacker would look for
+ * (an invalid header value from a hostile token header was one, fixed at its
+ * source too). This boundary is what keeps the blast radius at one request no
+ * matter which of those is found next.
+ */
+const httpServer = http.createServer((req, res) => {
+  handleRequest(req, res).catch((e) => {
+    logEvent("request_crash", { msg: (e as Error).message, url: redactUrl(req.url ?? "") },
+      `unhandled error in request handler: ${(e as Error).message}`);
+    // Only static, known-safe header values here: this is the last line of
+    // defence, and a throw inside it would defeat the purpose.
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        jsonrpc: "2.0",
+        // Even the last-resort answer names the fault. Reaching here at all is
+        // a bug in this server, and the one thing that makes such a bug
+        // findable from a user's report is the message they can quote.
+        error: { code: -32603, message: `Unhandled error in octen-mcp: ${(e as Error).message}` },
+        id: null,
+      }));
+    } else {
+      res.destroy();
+    }
+  });
+});
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  for (const [k, v] of Object.entries(CORS_HEADERS)) res.setHeader(k, v);
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const path = (req.url ?? "").split("?")[0];
+
+  // Liveness AND readiness — deliberately no upstream round-trip, so a health
+  // probe cannot consume quota or mask an API-side incident as our own. The
+  // drain flip is what makes rolling deploys graceful.
+  if (path === "/healthz") {
+    json(res, draining ? 503 : 200, {
+      status: draining ? "draining" : "ok",
+      name: "octen-mcp",
+      version: VERSION,
+    });
+    return;
+  }
+
+  // Both spellings: the bare well-known (what some clients try first) and the
+  // path-derived one this deployment advertises in its challenge.
+  if (
+    OAUTH_ENABLED &&
+    req.method === "GET" &&
+    (path === "/.well-known/oauth-protected-resource" || path === PRM_PATH)
+  ) {
+    json(res, 200, prmDocument());
+    return;
+  }
+
+  // `/mcp/` too: a trailing slash is the commonest paste artifact in a URL a
+  // human copies into a client config, and answering it with 404 makes a
+  // working deployment look broken for a reason nobody inspects. `/mcp/oauth`
+  // is the same endpoint with the forced-authorization behaviour below.
+  if (path !== "/mcp" && path !== "/mcp/" && path !== "/mcp/oauth") {
+    // Name the endpoints rather than a bare "not found": the commonest cause
+    // is a client configured with the origin instead of the full MCP URL, and
+    // that is invisible from the status code alone.
+    json(res, 404, {
+      error: `No handler for ${path || "/"}. This server exposes POST /mcp (MCP Streamable HTTP) ` +
+        `and GET /healthz` + (OAUTH_ENABLED ? `, plus GET ${PRM_PATH}.` : "."),
+    });
+    return;
+  }
+
+  if (req.method !== "POST") {
+    // Stateless: no standalone SSE stream to GET, no session to DELETE.
+    json(
+      res, 405,
+      { jsonrpc: "2.0", error: { code: -32000, message: "Method not allowed. This is a stateless MCP endpoint; use POST." }, id: null },
+      { Allow: "POST, OPTIONS" }
+    );
+    return;
+  }
+
+  if (draining) {
+    json(res, 503, {
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Server is shutting down; retry against another instance." },
+      id: null,
+    }, { "Retry-After": "1" });
+    return;
+  }
+
+  // Cheap early rejection on the declared size, before anything reads the
+  // stream. Not a cap on its own — a chunked request declares nothing — which
+  // is why `readBody` meters the bytes that actually arrive.
+  const declaredLength = Number(req.headers["content-length"] ?? "0");
+  if (declaredLength > MAX_BODY_BYTES) {
+    json(res, 413, {
+      jsonrpc: "2.0",
+      error: { code: -32000, message: `Request body exceeds ${MAX_BODY_BYTES} bytes ` +
+          `(OCTEN_MCP_MAX_BODY). Sending an image as base64 needs this raised.` },
+      id: null,
+    });
+    return;
+  }
+
+  // Counted from here, before credential resolution rather than after it.
+  // Starting the count at dispatch left a request blocked on the resolve-key
+  // round-trip invisible to the drain, so SIGTERM saw zero in flight and
+  // exited underneath it — the client gets a reset instead of the clean 503
+  // the drain exists to give it.
+  inFlight++;
+  // The body's claim on the shared budget is released with the response, not
+  // with the read — see BodyCharge.
+  const bodyCharge = newBodyCharge();
+  res.on("close", () => { inFlight--; bodyCharge.release(); });
+
+  const apiKey = apiKeyFrom(req);
+
+  // OAuth trigger. When this deployment has an authorization server, a request
+  // carrying NO credential is answered with the challenge — on every method,
+  // `initialize` included, not only on a `?login` entrypoint.
+  //
+  // This is the MCP spec's trigger and the only one clients act on: 401 +
+  // `WWW-Authenticate` → fetch the advertised metadata → discover the AS →
+  // authorize. Gating it behind a query parameter made the flow depend on the
+  // user pasting `…/mcp?login` rather than `…/mcp`; paste the plain URL and
+  // `initialize` answers 200, so the client concludes the server needs no
+  // authorization and never offers to log in. The failure then surfaces at the
+  // first `tools/call` as a tool-level "no API key on this request" — which
+  // reads as a misconfiguration the user should fix, not as an invitation to
+  // authorize. Connected-but-never-authorized, with a misleading error at the
+  // end of it.
+  //
+  // The cost is that anonymous `tools/list` is no longer possible against an
+  // OAuth-enabled deployment. That was worth having when a credential could
+  // only be a bare key pasted into a config; it is not worth the flow above
+  // once there is an authorization server to send people to. Deployments
+  // without one (self-hosted, bare keys only) are untouched: no AS to point
+  // at, so nothing is advertised and enforcement stays at call time.
+  //
+  // Presence of a credential — even an unvalidated one — passes through here;
+  // an invalid or expired JWT is answered 401 at validation just below, which
+  // is what drives a client's automatic refresh.
+  // Forced authorization. `/mcp/oauth` and `?login` issue the challenge even
+  // when a credential IS present, which is the one thing the rule above cannot
+  // express: someone already using a bare API key has no way to switch to
+  // OAuth, because their key stops the challenge from ever being sent.
+  //
+  // Worth separating from the history here: `?login` used to be the *gate* on
+  // the challenge — no `?login`, no challenge — and that was removed because
+  // it made the whole flow depend on the user pasting a query parameter no
+  // client adds on its own. What is added back is the opposite direction, and
+  // does not reintroduce that gate: an uncredentialed request is still
+  // challenged everywhere.
+  //
+  // With no authorization server configured there is nothing to force, so this
+  // is inert and the path behaves as a plain alias — better than a 404 that
+  // makes a working deployment look broken.
+  const forceLogin = path === "/mcp/oauth" || queryOf(req).has("login");
+
+  if (OAUTH_ENABLED && (apiKey === undefined || forceLogin)) {
+    logEvent("oauth_challenge", {
+      forced: forceLogin && apiKey !== undefined ? true : undefined,
+      ua: (req.headers["user-agent"] ?? "").toString().slice(0, 60) || undefined,
+    },
+      `401 challenge issued (${apiKey === undefined ? "no credential" : "forced"})`);
+    json(res, 401, {
+      jsonrpc: "2.0",
+      error: {
+        code: -32001,
+        // Two different situations reach this response, and telling a caller
+        // who *did* send a key that they sent none is the kind of wrong
+        // message that sends someone to check their config for an hour.
+        message: apiKey === undefined
+          ? "No credential on this request. Send an Octen API key as `x-api-key: <key>` " +
+            "(or `Authorization: Bearer <key>`, or the `octenApiKey` query parameter), or " +
+            `complete the OAuth flow advertised in the WWW-Authenticate header (metadata: ${PRM_URL}).`
+          : "This endpoint requires authorization even when a key is supplied. Complete the " +
+            `OAuth flow advertised in the WWW-Authenticate header (metadata: ${PRM_URL}), or ` +
+            "use /mcp to keep using the key you sent.",
+      },
+      id: null,
+    }, { "WWW-Authenticate": `Bearer resource_metadata="${PRM_URL}"` });
+    return;
+  }
+
+  // JWT path (spec §A3): a Bearer that is structurally an access token is
+  // verified and exchanged for the grant's API key BEFORE dispatch. Failure
+  // semantics split on purpose: token problems are transport-level 401 with a
+  // challenge (clients auto-refresh on it; an isError would break that loop),
+  // backend problems are 503 (the token may be fine — don't make the client
+  // burn its refresh flow on our outage). Bare API keys never enter this path.
+  let effectiveKey = apiKey;
+  if (OAUTH_ENABLED && apiKey !== undefined && looksLikeAccessToken(apiKey)) {
+    try {
+      effectiveKey = await apiKeyFromAccessToken(RS_CONFIG, apiKey);
+    } catch (e) {
+      if (e instanceof TokenInvalidError) {
+        logEvent("oauth_reject", { reason: e.message }, `access token rejected: ${e.message}`);
+        // The specific reason goes in the body too, not only in the challenge:
+        // an agent (and the human reading its transcript) sees the JSON-RPC
+        // error, and "invalid or expired" alone cannot distinguish a clock
+        // skew from a trailing slash in the resource URL from a revoked
+        // grant — three problems with three unrelated fixes. This is the
+        // failure mode that made the earlier field reports unactionable.
+        json(res, 401, {
+          jsonrpc: "2.0",
+          error: { code: -32001, message: `Access token rejected: ${e.message}` },
+          id: null,
+        }, {
+          "WWW-Authenticate":
+            `Bearer error="invalid_token", error_description="${headerSafe(e.message)}", ` +
+            `resource_metadata="${PRM_URL}"`,
+        });
+        return;
+      }
+      const msg = e instanceof OAuthBackendError ? e.message : (e as Error).message;
+      logEvent("oauth_backend_error", { reason: msg }, `oauth backend unavailable: ${msg}`);
+      json(res, 503, {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message:
+            `Could not verify this access token because an Octen-side dependency is unavailable: ${msg}. ` +
+            "The token itself may be fine — retry shortly rather than re-authorizing.",
+        },
+        id: null,
+      }, { "Retry-After": "5" });
+      return;
+    }
+  }
+
+  // Per-connection tool selection. Validated here rather than inside the
+  // server so a bad name is one clear 400 instead of a connection that comes
+  // up looking healthy and is missing a tool.
+  const selection = parseToolSelection(queryOf(req));
+  if ("error" in selection) {
+    json(res, 400, {
+      jsonrpc: "2.0",
+      error: { code: -32602, message: selection.error },
+      id: null,
+    });
+    return;
+  }
+
+  logEvent("http_request", {
+    tools: selection.tools ? selection.tools.join(",") : undefined,
+    key_prefix: apiKey ? keyFingerprint(apiKey) : undefined,
+    ua: (req.headers["user-agent"] ?? "").toString().slice(0, 60) || undefined,
+  },
+    `http POST /mcp key=${apiKey ? keyFingerprint(apiKey) : "(none)"} ` +
+    `ua=${(req.headers["user-agent"] ?? "-").toString().slice(0, 60)}`);
+
+  // A fresh pair per request: request IDs cannot collide across concurrent
+  // POSTs, and the closure pins this request's key to this request's calls.
+  const server = createOctenServer({ getApiKey: () => effectiveKey, transport: "http", tools: selection.tools });
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  res.on("close", () => {
+    void transport.close();
+    void server.close();
+  });
+
+  let parsed: unknown;
+  try {
+    const raw = await readBody(req, MAX_BODY_BYTES, bodyCharge);
+    parsed = raw === "" ? undefined : JSON.parse(raw);
+  } catch (e) {
+    if (e instanceof BodyBudgetExceededError) {
+      // Capacity, not a bad request: the same call will work shortly, and the
+      // caller has nothing to fix. Drained like the 413 below so the answer
+      // survives the close.
+      logEvent("body_budget_exceeded", { inflight: inflightBodyBytes, budget: MAX_INFLIGHT_BODY_BYTES },
+        `refused: in-flight bodies at ${inflightBodyBytes} of ${MAX_INFLIGHT_BODY_BYTES} bytes`);
+      res.writeHead(503, { "Content-Type": "application/json", Connection: "close", "Retry-After": "1" });
+      res.end(JSON.stringify({
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Server is at capacity for request bodies of this size; retry shortly. " +
+            "(Concurrency ceiling: OCTEN_MCP_MAX_INFLIGHT_BODY.)",
+        },
+        id: null,
+      }));
+      req.resume();
+      const cut = setTimeout(() => req.destroy(), BODY_DRAIN_MS);
+      req.once("end", () => clearTimeout(cut));
+      req.once("close", () => clearTimeout(cut));
+      return;
+    }
+    if (e instanceof BodyTooLargeError) {
+      // `Connection: close` — the body is still arriving, so this socket
+      // cannot carry another request.
+      res.writeHead(413, { "Content-Type": "application/json", Connection: "close" });
+      res.end(JSON.stringify({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: `Request body exceeds ${MAX_BODY_BYTES} bytes ` +
+          `(OCTEN_MCP_MAX_BODY). Sending an image as base64 needs this raised.` },
+        id: null,
+      }));
+
+      // Then keep reading — and discarding — until the client stops.
+      //
+      // Hanging up here instead does not work, and the reason is TCP rather
+      // than Node: closing while the peer is mid-send sends a reset, and a
+      // reset discards whatever response bytes were still in flight. Measured
+      // both ways against this server: a client that stopped after 128 KB
+      // received the 413, while a client that kept sending received nothing at
+      // all — only ECONNRESET. That is precisely the unexplained failure this
+      // cap exists to replace, so the cap would have been self-defeating.
+      //
+      // Discarding costs no memory (readBody stops accumulating the moment it
+      // rejects), and the timer bounds how long a client that ignores the 413
+      // can keep us absorbing its bytes.
+      const drainStarted = Date.now();
+      req.resume();
+      const cutoff = setTimeout(() => {
+        logEvent("body_drain_cutoff", { limit: MAX_BODY_BYTES, budget_ms: BODY_DRAIN_MS },
+          `oversized body still arriving after ${BODY_DRAIN_MS}ms; closing`);
+        req.destroy();
+      }, BODY_DRAIN_MS);
+      // `end` and `close` can both fire; the guard keeps this to one line.
+      let logged = false;
+      const stopDraining = () => {
+        clearTimeout(cutoff);
+        if (logged) return;
+        logged = true;
+        logEvent("body_drained", { limit: MAX_BODY_BYTES, drain_ms: Date.now() - drainStarted },
+          `413 sent and the rest of the body drained in ${Date.now() - drainStarted}ms`);
+      };
+      req.once("end", stopDraining);
+      req.once("close", stopDraining);
+      return;
+    }
+    json(res, 400, {
+      jsonrpc: "2.0",
+      // -32700 is the JSON-RPC parse error; naming the parser's own complaint
+      // is what turns "it just fails" into a fixable report.
+      error: { code: -32700, message: `Could not parse the request body as JSON: ${(e as Error).message}` },
+      id: null,
+    });
+    return;
+  }
+
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, parsed);
+  } catch (e) {
+    logEvent("http_error", { msg: (e as Error).message }, `http transport error: ${(e as Error).message}`);
+    if (!res.headersSent) {
+      json(res, 500, {
+        jsonrpc: "2.0",
+        // The reason travels with the response. A bare "Internal server error"
+        // leaves the caller unable to tell our bug from their malformed frame,
+        // and leaves us with a report that contains nothing to search for.
+        error: { code: -32603, message: `MCP transport error: ${(e as Error).message}` },
+        id: null,
+      });
+    }
+  }
+}
+
+function shutdown(signal: string): void {
+  if (draining) {
+    // Second signal: the operator (or a local ctrl-c) wants out now.
+    process.exit(130);
+  }
+  draining = true;
+  // The budget is logged, not just used: it is the number that decides whether
+  // this pod exits on its own or gets SIGKILLed, it has to stay under the
+  // pod's terminationGracePeriodSeconds, and an operator comparing the two has
+  // no other way to see what this process actually resolved the env var to.
+  logEvent("drain_start", { signal, in_flight: inFlight, budget_ms: DRAIN_TIMEOUT_MS },
+    `drain started on ${signal}, ${inFlight} request(s) in flight, budget ${DRAIN_TIMEOUT_MS}ms`);
+  // Keep LISTENING through the drain. Readiness failing (healthz 503) is what
+  // takes this pod out of rotation; closing the listener here instead would
+  // RST any client that races endpoint removal, where the draining gate above
+  // answers 503 + Retry-After and lets it fail over cleanly. The listener is
+  // torn down by process exit.
+  const deadline = Date.now() + DRAIN_TIMEOUT_MS;
+  const timer = setInterval(() => {
+    if (inFlight === 0 || Date.now() > deadline) {
+      const forced = inFlight > 0;
+      logEvent("drain_complete", { in_flight: inFlight, forced },
+        `drain complete, in_flight=${inFlight}${forced ? " (deadline hit)" : ""}`);
+      clearInterval(timer);
+      process.exit(forced ? 1 : 0);
+    }
+  }, 200);
+}
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
+httpServer.listen(PORT, () => {
+  const actual = (httpServer.address() as { port: number }).port;
+  // stderr, like every other diagnostic — stdout stays silent even though this
+  // transport doesn't use it, so log-scraping setups behave the same for both.
+  console.error(`[octen-mcp] v${VERSION} HTTP transport listening on :${actual}/mcp`);
+});

--- a/src/imageSearch.ts
+++ b/src/imageSearch.ts
@@ -15,7 +15,7 @@
  */
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { formatMeta, errorResult } from "./search.js";
-import { postJson, OctenHttpError, bodyReadFailure } from "./http.js";
+import { postJson, OctenHttpError, bodyReadFailure, missingKeyMessage, type HandlerContext } from "./http.js";
 
 /** Client-side ceiling when the caller passes no `timeout`. */
 const IMAGE_SEARCH_TIMEOUT_SEC = 30;
@@ -26,7 +26,7 @@ const API_KEY = process.env.OCTEN_API_KEY;
 export const imageSearchTool: Tool = {
   name: "image_search",
   description:
-    `Find images on the web by text query, and optionally by a reference image — returns ranked results (title, source page, dimensions, thumbnail, description, summary). In Beta; contact us to request beta access. Pass a text \`query\`, and optionally an \`image_url\` to search by reference image. Set \`topic\` to \`design\` for UI design references — each result then carries a structured style \`summary\` and an \`html_snippet\` for building/restyling frontends. Use this when the user wants pictures, photos, diagrams, screenshots, or visual references — not for general text web search.
+    `Find images on the web by text query OR by a reference image — returns ranked results (title, source page, dimensions, thumbnail, description, summary). In Beta; contact us to request beta access. Pass exactly one of: a text \`query\`, an \`image_url\` (a picture already on the web), or \`image_data\` (base64, for a picture you hold). Never more than one. Set \`topic\` to \`design\` for UI design references — each result then carries a structured style \`summary\` and an \`html_snippet\` for building/restyling frontends. Use this when the user wants pictures, photos, diagrams, screenshots, or visual references — not for general text web search.
 
 keywords: find images, image search, photos, pictures, screenshots, visual reference, diagram, icon, illustration, UI design, reference image`,
   inputSchema: {
@@ -35,13 +35,26 @@ keywords: find images, image search, photos, pictures, screenshots, visual refer
       query: {
         type: "string",
         maxLength: 500,
-        description: "Text query describing the images to find.",
+        description: "Text query describing the images to find. Exactly one of `query`, `image_url` or `image_data` — never more than one.",
       },
       image_url: {
         type: "string",
         description:
-          "Optional public image URL to search by reference image (visual " +
-          "similarity), in addition to the text `query`.",
+          "Public image URL to search by visual similarity. Exactly one of " +
+          "`query`, `image_url` or `image_data` — never more than one.",
+      },
+      image_data: {
+        type: "string",
+        // 5 MiB is the encoded ceiling the API documents ("at most 5MB after
+        // encoding"), so it is measured on this string, not on the picture it
+        // decodes to.
+        maxLength: 5 * 1024 * 1024,
+        description:
+          "Base64-encoded image to search by visual similarity, for an image " +
+          "you hold rather than one already on the web. At most 5MB encoded; " +
+          "JPEG, PNG, WEBP, BMP, TIFF, ICO, DIB, ICNS or SGI. A `data:` URI is " +
+          "accepted — its payload is used. Exactly one of `query`, `image_url` " +
+          "or `image_data` — never more than one.",
       },
       topic: {
         type: "string",
@@ -68,21 +81,6 @@ keywords: find images, image search, photos, pictures, screenshots, visual refer
         items: { type: "string" },
         description: "Drop results from these domains.",
       },
-      time_range: {
-        type: "string",
-        enum: ["day", "week", "month", "year", "d", "w", "m", "y"],
-        description:
-          "Relative time window (e.g. `week`, `month`). Mutually exclusive with " +
-          "`start_time`/`end_time` — if both are given, the absolute range wins.",
-      },
-      start_time: {
-        type: "string",
-        description: "Lower bound for the time window, ISO 8601 (e.g. '2025-01-01T00:00:00Z').",
-      },
-      end_time: {
-        type: "string",
-        description: "Upper bound for the time window, ISO 8601.",
-      },
       safesearch: {
         type: "string",
         enum: ["off", "strict"],
@@ -99,8 +97,9 @@ keywords: find images, image search, photos, pictures, screenshots, visual refer
           max_tokens: {
             type: "integer",
             minimum: 100,
+            maximum: 100000,
             default: 5000,
-            description: "Max tokens per HTML snippet (min 100). Default 5000.",
+            description: "Max tokens per HTML snippet (100-100000). Default 5000.",
           },
         },
       },
@@ -111,7 +110,10 @@ keywords: find images, image search, photos, pictures, screenshots, visual refer
         description: "Request timeout in seconds (1-60). Defaults to 30s if unset.",
       },
     },
-    required: ["query"],
+    // No `required`: exactly one of `query` / `image_url` must be present, which
+    // JSON Schema can only say with `oneOf`. Requiring `query` here made the
+    // documented image-only search unreachable; the handler enforces the real
+    // rule and says which one is missing.
   },
 };
 
@@ -123,40 +125,71 @@ interface HtmlSnippetOptions {
 interface ImageSearchArgs {
   query: string;
   image_url?: string;
+  image_data?: string;
   topic?: "general" | "design";
   count?: number;
   include_domains?: string[];
   exclude_domains?: string[];
-  time_range?: "day" | "week" | "month" | "year" | "d" | "w" | "m" | "y";
-  start_time?: string;
-  end_time?: string;
   safesearch?: "off" | "strict";
   html_snippet?: HtmlSnippetOptions;
   timeout?: number;
 }
 
 /** Handler — POSTs to Octen Image Search and reshapes the response for the LLM. */
-export async function handleImageSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+
+/** `data:image/png;base64,AAAA` → `AAAA`; anything else is returned unchanged. */
+function stripDataUri(v: string): string {
+  const m = /^data:[^;,]*;base64,(.*)$/s.exec(v.trim());
+  return m ? m[1] : v.trim();
+}
+
+export async function handleImageSearch(rawArgs: Record<string, unknown>, ctx?: HandlerContext): Promise<CallToolResult> {
   const args = rawArgs as unknown as ImageSearchArgs;
 
-  if (typeof args.query !== "string" || args.query.trim().length === 0) {
-    return errorResult("`query` must be a non-empty string");
-  }
-  if (!API_KEY) {
+  // Exactly one input — text, image URL, or image bytes. The API's `inputs`
+  // array is documented `maxItems: 1`, and sending two earns `Invalid params.
+  // Inputs exceeds 1 entries` from upstream. This tool used to require `query`
+  // and describe `image_url` as usable "in addition" to it, so the
+  // documented-and-supported combination (a reference image on its own) was
+  // unreachable while the unsupported one was the advertised path.
+  //
+  // The rule is enforced here rather than in the schema because expressing
+  // "exactly one of" needs `oneOf`, which the validator deliberately does not
+  // implement — see src/validate.ts.
+  const filled = (["query", "image_url", "image_data"] as const)
+    .filter((k) => typeof args[k] === "string" && (args[k] as string).trim() !== "");
+  if (filled.length > 1) {
     return errorResult(
-      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
-      "and add it to your MCP client config (see README)."
-    );
+      `Pass exactly one of \`query\`, \`image_url\` or \`image_data\` — got ` +
+      `${filled.map((k) => "`" + k + "`").join(" and ")}. This search takes a single input.`);
+  }
+  if (filled.length === 0) {
+    return errorResult(
+      "Pass one of `query` (text to search for), `image_url` (a public image URL to " +
+      "match visually), or `image_data` (base64 of an image you hold).");
+  }
+  // When a transport supplies ctx, it is authoritative — no env fallback. The
+  // stdio entry resolves the env key into ctx itself; falling back here would
+  // let an unauthenticated HTTP caller silently ride the deployment's own
+  // credential. The bare fallback exists only for direct in-process callers
+  // (the unit suites) that invoke handlers without a transport.
+  const apiKey = ctx ? ctx.apiKey : API_KEY;
+  if (!apiKey) {
+    return errorResult(missingKeyMessage(ctx));
   }
 
   // `timeout` is an HTTP-client concern; `query`/`image_url` are flattened into `inputs`.
-  const { timeout, query, image_url, ...payloadArgs } = args;
+  const { timeout, query, image_url, image_data, ...payloadArgs } = args;
 
-  // Build the multimodal inputs array from the flattened fields.
-  const inputs: Array<Record<string, unknown>> = [{ type: "text", data: query }];
-  if (typeof image_url === "string" && image_url.length > 0) {
-    inputs.push({ type: "image", url: image_url });
-  }
+  // Exactly one entry — the branch above has already established which.
+  //
+  // A `data:` URI is unwrapped rather than refused: its payload *is* the
+  // base64 the API wants, and it is the form every browser and screenshot
+  // tool produces. Rejecting it would be pedantry about a container.
+  const inputs: Array<Record<string, unknown>> =
+    filled[0] === "query"     ? [{ type: "text", data: query }]
+  : filled[0] === "image_url" ? [{ type: "image", url: image_url }]
+  :                             [{ type: "image", data: stripDataUri(image_data as string) }];
 
   // Drop undefined fields so server defaults apply.
   const body: Record<string, unknown> = { inputs };
@@ -167,6 +200,7 @@ export async function handleImageSearch(rawArgs: Record<string, unknown>): Promi
   let resp: Response;
   try {
     resp = await postJson({
+      apiKey,
       path: "/image-search",
       body,
       label: "Octen Image Search",
@@ -203,7 +237,13 @@ export async function handleImageSearch(rawArgs: Record<string, unknown>): Promi
   const total = results.length;
 
   if (total === 0) {
-    return { content: [{ type: "text", text: `No image results for "${args.query}".` }] };
+    // Names whichever input was actually used. Interpolating `query` here
+    // printed `No image results for "undefined"` for an image search, which
+    // reads like a bug in the caller's arguments rather than an empty result.
+    const subject = filled[0] === "query" ? `"${args.query}"`
+      : filled[0] === "image_url" ? `image ${args.image_url}`
+      : "the supplied image";
+    return { content: [{ type: "text", text: `No image results for ${subject}.` }] };
   }
 
   const blocks = results.map((r: any, i: number) => formatResult(r, i + 1, total));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,137 +1,21 @@
 #!/usr/bin/env node
 /**
- * Octen MCP server — exposes Octen's /search and /extract as LLM-callable tools.
+ * Octen MCP server — stdio entry.
  *
- * Transport: stdio (Claude Desktop / Claude Code / Cursor compatible).
- * The same Server + tool handlers can later be reused under an HTTP/SSE
- * transport without changing the tool definition.
+ * Transport: stdio (Claude Desktop / Claude Code / Cursor compatible). The
+ * server itself is assembled in `server.ts`, shared with the HTTP entry
+ * (`httpServer.ts`); this file only supplies what is stdio-specific — one user,
+ * whose API key comes from the environment.
  */
-import { createRequire } from "node:module";
-
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
 
-import { extractTool, handleExtract } from "./extract.js";
-import {
-  searchTool,
-  handleSearch,
-  newsSearchTool,
-  handleNewsSearch,
-  broadSearchTool,
-  handleBroadSearch,
-} from "./search.js";
-import { imageSearchTool, handleImageSearch } from "./imageSearch.js";
-import { videoSearchTool, handleVideoSearch } from "./videoSearch.js";
-import { debug } from "./http.js";
+import { createOctenServer, VERSION } from "./server.js";
 
-// Read the version from package.json rather than restating it here — the
-// hardcoded copy silently drifted (0.3.6 while the package shipped as 0.3.7),
-// which made the version a client reported useless for triaging bug reports.
-const require = createRequire(import.meta.url);
-const { version: VERSION } = require("../package.json") as { version: string };
-
-const server = new Server(
-  {
-    name: "octen-mcp",
-    version: VERSION,
-  },
-  {
-    capabilities: {
-      tools: {}, // we expose tools (not resources or prompts in v1)
-    },
-  }
-);
-
-// Beta tools (image_search, video_search) are invite-only. A host can hide them
-// from tool discovery so agents never surface capabilities most accounts can't use.
-// Default preserves existing behavior (Beta tools listed); set
-// OCTEN_ENABLE_BETA_TOOLS to a falsy value (false/0/off/no) to omit them entirely.
-const betaFlag = (process.env.OCTEN_ENABLE_BETA_TOOLS ?? "").trim().toLowerCase();
-const BETA_TOOLS_ENABLED = !["false", "0", "off", "no"].includes(betaFlag);
-const BETA_TOOL_NAMES = new Set(["image_search", "video_search"]);
-
-const enabledTools = [
-  searchTool,
-  newsSearchTool,
-  broadSearchTool,
-  extractTool,
-  ...(BETA_TOOLS_ENABLED ? [imageSearchTool, videoSearchTool] : []),
-];
-
-// 1. List available tools — clients call this first to discover what we offer.
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: enabledTools,
-}));
-
-// 2. Dispatch tool calls.
-let callSeq = 0;
-
-server.setRequestHandler(CallToolRequestSchema, async (req) => {
-  const { name, arguments: args } = req.params;
-
-  // Stamp the moment the call reached this process, before any of our work.
-  //
-  // This is the measurement that settles who owns a slow call. Subtract this
-  // timestamp from the one the MCP client recorded when it issued the tool
-  // call, and the difference is time spent entirely outside octen-mcp — in the
-  // host, or in whatever relays between them. Without it, a client-side stopwatch
-  // attributes that delay to us by default, because we are the last thing in
-  // the chain that reports anything at all.
-  const seq = ++callSeq;
-  const receivedAt = Date.now();
-  debug(`call #${seq} received tool=${name}`);
-
-  // In a `finally`, not around each return: the beta-disabled and unknown-tool
-  // branches return without touching the switch, and a handler that throws
-  // (anything not an OctenHttpError is deliberately rethrown) skipped it
-  // entirely. Each of those logged "received" and never "returning", so
-  // scanning the trace for calls that never came back — the reason the pair
-  // exists — produced false hangs.
-  const finish = () =>
-    debug(`call #${seq} returning tool=${name} handler_total=${Date.now() - receivedAt}ms`);
-
-  try {
-    if (!BETA_TOOLS_ENABLED && BETA_TOOL_NAMES.has(name)) {
-      return {
-        isError: true,
-        content: [
-          { type: "text", text: `Tool "${name}" is disabled: Beta tools are turned off via OCTEN_ENABLE_BETA_TOOLS.` },
-        ],
-      };
-    }
-
-    switch (name) {
-      case "search":
-        return await handleSearch(args ?? {});
-      case "news_search":
-        return await handleNewsSearch(args ?? {});
-      case "broad_search":
-        return await handleBroadSearch(args ?? {});
-      case "extract":
-        return await handleExtract(args ?? {});
-      case "image_search":
-        return await handleImageSearch(args ?? {});
-      case "video_search":
-        return await handleVideoSearch(args ?? {});
-      default:
-        // MCP convention: return an error result, don't throw.
-        return {
-          isError: true,
-          content: [
-            { type: "text", text: `Unknown tool: ${name}` },
-          ],
-        };
-    }
-  } finally {
-    finish();
-  }
+const server = createOctenServer({
+  getApiKey: () => process.env.OCTEN_API_KEY,
+  transport: "stdio",
 });
 
-// 3. Wire up the stdio transport and start listening.
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/oauthRs.ts
+++ b/src/oauthRs.ts
@@ -1,0 +1,404 @@
+/**
+ * OAuth resource-server side: verify an access token, exchange its grant for
+ * an API key.
+ *
+ * The token contract (read from the authorization server's implementation,
+ * not assumed): a fosite-issued self-contained RS256 JWT with `iss`, `aud`
+ * (single value — the resource URL), `exp`/`iat`, `scp` (fosite's convention:
+ * an ARRAY, not a `scope` string), `sub`, and `grant_id` — deliberately no
+ * key identifier of any kind, so a leaked token can only ever be exchanged
+ * for the one key its grant was bound to, via the authenticated internal
+ * resolve endpoint.
+ *
+ * Verification is plain node:crypto over the JWKS — RS256 signature checks
+ * need no JOSE dependency, and this repo keeps its runtime dependency list
+ * deliberately short. Key rotation is handled the standard way: unknown `kid`
+ * triggers one JWKS refetch before rejecting.
+ *
+ * Failure taxonomy matters more than usual here (spec §A3.5): a token problem
+ * is answered HTTP 401 + WWW-Authenticate so clients auto-refresh — burying
+ * it in a tool-result isError breaks the refresh loop and degrades to
+ * "mysterious hourly failures". An *infrastructure* problem (JWKS or resolve
+ * endpoint unreachable) is 503: the token may be fine, and a client that
+ * burns its refresh flow on our outage ends up logged out for nothing.
+ */
+import { createPublicKey, verify as cryptoVerify, type KeyObject } from "node:crypto";
+import { fetch as undiciFetch } from "undici";
+
+import { logEvent, dispatcher, envInt } from "./http.js";
+
+/** Thrown for token problems → transport 401 (client should refresh/re-auth). */
+export class TokenInvalidError extends Error {}
+/** Thrown for backend problems → transport 503 (token may be fine; retry). */
+export class OAuthBackendError extends Error {}
+
+/**
+ * Name what actually failed, for a `fetch` rejection.
+ *
+ * `fetch` rejects with a bare `TypeError: fetch failed`; the reason lives on
+ * `err.cause.code`. Passing the outer message through produces "JWKS fetch
+ * failed: fetch failed", which tells a reader nothing they did not already
+ * know — the same dead end that made the 0.3.7 field reports unactionable, and
+ * this time on a path where the answer reaches the user as a 503.
+ *
+ * Deliberately code-and-reason only, no URL or address: the resolve endpoint
+ * is an in-cluster address and these messages are returned over the public
+ * internet. `timeoutMs` is stated because "did it refuse or did it hang" is
+ * the first question, and the two need opposite fixes.
+ */
+function fetchFailureReason(e: unknown, timeoutMs: number): string {
+  const err = e as (Error & { cause?: { code?: string; message?: string; errors?: unknown[] } }) | undefined;
+  if (err?.name === "TimeoutError" || err?.name === "AbortError") {
+    return `no response within ${timeoutMs}ms`;
+  }
+  // A body read fails these two ways as well, and they are not the same fault:
+  // non-JSON means something answered and it was the wrong thing (a proxy
+  // error page, most often), while a socket code means the answer was cut off.
+  if (err?.name === "SyntaxError") return "the body was not JSON";
+  const cause = err?.cause;
+  const subs = Array.isArray(cause?.errors) ? (cause.errors as { code?: string }[]) : [];
+  const code = cause?.code ?? subs[0]?.code ?? err?.name;
+  const detail = cause?.message;
+  if (code && detail && detail !== code) return `${code} (${detail})`;
+  return code ?? detail ?? "unknown transport failure";
+}
+
+const CLOCK_TOLERANCE_SEC = 60;
+const JWKS_TTL_MS = 5 * 60 * 1000;
+/**
+ * Floor between two unknown-`kid` refetches. The refetch exists so a key
+ * published mid-rotation is picked up without waiting out the TTL, and that
+ * only needs to happen once per rotation — but the trigger is an *unverified*
+ * token header, so without a floor each request carrying a made-up `kid`
+ * becomes one JWKS request to the authorization server. Measured before this
+ * cooldown: 10 unauthenticated requests produced 11 JWKS fetches, turning our
+ * own AS into the amplification target. 10s keeps rotation effectively
+ * immediate while capping the reachable rate at one fetch per window.
+ *
+ * The cost of the window is bounded and one-sided: a key published *and* used
+ * within it is rejected until the window passes, so a rotation is delayed by
+ * at most this long — never broken. Tunable only so the suite can exercise
+ * both sides of it without sleeping ten seconds; lowering it in production
+ * widens the amplification factor back out by the same ratio.
+ */
+const JWKS_REFETCH_COOLDOWN_MS = envInt("OCTEN_JWKS_REFETCH_COOLDOWN_MS", 10_000, 0);
+const JWKS_TIMEOUT_MS = 5_000;
+/** Tighter than JWKS: this one runs on every OAuth tool call the cache misses. */
+const RESOLVE_TIMEOUT_MS = 3_000;
+/**
+ * How long a resolved grant→key mapping is reused before going back to the
+ * authorization server.
+ *
+ * This is the revocation-propagation window, and it is a deliberate trade, so
+ * it is configuration rather than a buried constant: measured on pre, a token
+ * revoked at t=0 still worked at t=45s and was refused at t=60s.
+ *
+ * Not zero, because resolving on every call would put a synchronous dependency
+ * on the dashboard in front of every single tool call — strictly more fragile
+ * than the window is harmful. And the window is an *increment*, not the whole
+ * exposure: an access token's own lifetime is ~3600s, so revocation already
+ * takes effect on that scale; this only adds to the case where someone revokes
+ * deliberately and expects it to bite immediately. Lower it if that case
+ * matters more than the extra load on the resolve endpoint.
+ */
+const RESOLVE_TTL_MS = envInt("OCTEN_OAUTH_RESOLVE_CACHE_TTL_MS", 60 * 1000, 0);
+const RESOLVE_CACHE_MAX = 10_000;
+
+/**
+ * `kid` is attacker-controlled: it arrives inside an unverified token header
+ * and is read before any signature check. It reaches a log line and — via the
+ * caller's `WWW-Authenticate` — an HTTP response header, so anything outside
+ * printable ASCII must not survive. A CRLF here previously reached
+ * `res.writeHead`, which rejects it with `ERR_INVALID_CHAR` from inside the
+ * request handler: one unauthenticated request, process gone.
+ *
+ * Sanitised rather than dropped, because "which key id did it claim" is the
+ * one fact that makes a rotation bug diagnosable.
+ */
+function safeText(v: unknown, max = 64): string {
+  const clean = String(v).replace(/[^\x20-\x7e]/g, "").replace(/["\\]/g, "").slice(0, max);
+  return clean === "" ? "(empty)" : clean;
+}
+
+export interface OAuthRsConfig {
+  /** AS base URL — also the expected `iss`, byte-for-byte. */
+  authorizationServer: string;
+  /** This deployment's resource URL — the expected `aud`, byte-for-byte. */
+  resource: string;
+  /** Internal resolve endpoint; absent = JWT path disabled (bare keys only). */
+  resolveUrl?: string;
+  /** Shared secret for the resolve endpoint's X-Octen-Service-Token header. */
+  resolveToken?: string;
+}
+
+function b64urlJson(part: string): any {
+  return JSON.parse(Buffer.from(part, "base64url").toString("utf8"));
+}
+
+/**
+ * Cheap structural test, run before any crypto: three dot-separated segments
+ * whose first segment decodes to a JSON object carrying a string `alg`. A bare
+ * Octen API key cannot match, so the two credential forms sharing one
+ * `Authorization` header do not collide.
+ *
+ * Deliberately shape-only. Requiring `alg === "RS256"` and a `kid` here — the
+ * first version of this — routed every JWT this server cannot verify into the
+ * *API key* path instead: measured, a token with `alg: none`, one signed
+ * HS256, and one missing `kid` were each forwarded verbatim to the upstream as
+ * an API key and answered HTTP 200 with an "Invalid API Key" tool error. Two
+ * things wrong with that. A client holding a bearer token needs 401 + a
+ * challenge to know it should re-authorize; a tool-level error reads as a
+ * backend fault it should retry, so it never does. And it sprays a whole
+ * bearer token — possibly one minted for some other audience — at our API
+ * gateway, where it lands in request logs as if it were a key.
+ *
+ * So: anything token-shaped is judged as a token, and the specific reason
+ * (unsupported algorithm, no kid, bad signature, expired) comes back as a 401.
+ * Anything else is a key, and a wrong key still earns the tool-level "check
+ * your key" error — which is the right answer for that case.
+ */
+export function looksLikeAccessToken(value: string): boolean {
+  const parts = value.split(".");
+  if (parts.length !== 3) return false;
+  try {
+    const header = b64urlJson(parts[0]);
+    return typeof header === "object" && header !== null && typeof header.alg === "string";
+  } catch {
+    return false;
+  }
+}
+
+// ---- JWKS ------------------------------------------------------------------
+
+interface Jwk { kid: string; kty: string; n?: string; e?: string; [k: string]: unknown }
+
+let jwksKeys = new Map<string, KeyObject>();
+let jwksFetchedAt = 0;
+/** Start of the last refetch *attempt* — failures count, or a down AS invites hammering. */
+let jwksAttemptedAt = 0;
+/** In-flight fetch, shared so a burst of concurrent misses makes one request. */
+let jwksInFlight: Promise<void> | undefined;
+
+/** One JWKS fetch at a time, however many callers miss the cache at once. */
+function fetchJwks(cfg: OAuthRsConfig): Promise<void> {
+  if (jwksInFlight) return jwksInFlight;
+  jwksAttemptedAt = Date.now();
+  jwksInFlight = fetchJwksOnce(cfg).finally(() => { jwksInFlight = undefined; });
+  return jwksInFlight;
+}
+
+async function fetchJwksOnce(cfg: OAuthRsConfig): Promise<void> {
+  // Path is the AS implementation's fixed convention (metadata builds
+  // jwks_uri as issuer + this path), so no discovery round-trip is needed.
+  const url = `${cfg.authorizationServer}/api/oauth/jwks`;
+  let res: Awaited<ReturnType<typeof undiciFetch>>;
+  try {
+    // Same dispatcher as every other outbound call: proxy environment honoured,
+    // sockets held between calls. Without it this path silently uses undici's
+    // global default and cannot reach the AS from behind a proxy.
+    res = await undiciFetch(url, { signal: AbortSignal.timeout(JWKS_TIMEOUT_MS), dispatcher });
+  } catch (e) {
+    throw new OAuthBackendError(
+      `could not reach the authorization server's JWKS endpoint: ${fetchFailureReason(e, JWKS_TIMEOUT_MS)}`);
+  }
+  if (res.status !== 200) {
+    throw new OAuthBackendError(`the authorization server's JWKS endpoint answered HTTP ${res.status}`);
+  }
+  let doc: { keys?: Jwk[] };
+  try {
+    doc = (await res.json()) as { keys?: Jwk[] };
+  } catch (e) {
+    throw new OAuthBackendError(
+      `the authorization server's JWKS response could not be read: ${fetchFailureReason(e, JWKS_TIMEOUT_MS)}`);
+  }
+  const next = new Map<string, KeyObject>();
+  for (const k of doc.keys ?? []) {
+    if (k.kty !== "RSA" || !k.kid) continue;
+    try {
+      next.set(k.kid, createPublicKey({ key: k as never, format: "jwk" }));
+    } catch {
+      /* skip malformed keys; a usable set may remain */
+    }
+  }
+  if (next.size === 0) {
+    throw new OAuthBackendError(
+      `the authorization server's JWKS contained no usable RSA keys ` +
+      `(${(doc.keys ?? []).length} key(s) present)`);
+  }
+  jwksKeys = next;
+  jwksFetchedAt = Date.now();
+}
+
+async function keyFor(cfg: OAuthRsConfig, kid: string): Promise<KeyObject> {
+  if (Date.now() - jwksFetchedAt > JWKS_TTL_MS) await fetchJwks(cfg);
+  let key = jwksKeys.get(kid);
+  if (!key && Date.now() - jwksAttemptedAt >= JWKS_REFETCH_COOLDOWN_MS) {
+    // Rotation path: a just-published kid is not in the cached set yet. Rate
+    // limited, because the caller is unauthenticated at this point — see
+    // JWKS_REFETCH_COOLDOWN_MS.
+    await fetchJwks(cfg);
+    key = jwksKeys.get(kid);
+  }
+  if (!key) {
+    throw new TokenInvalidError(
+      `the token is signed with a key this server does not know (kid=${safeText(kid)}); ` +
+      `the authorization server publishes ${[...jwksKeys.keys()].map((k) => safeText(k, 24)).join(", ") || "none"}`);
+  }
+  return key;
+}
+
+// ---- Verification -----------------------------------------------------------
+
+export interface VerifiedToken { grantId: string; subject?: string }
+
+export async function verifyAccessToken(cfg: OAuthRsConfig, token: string): Promise<VerifiedToken> {
+  const [h, p, sig] = token.split(".");
+  let header: any, payload: any;
+  try {
+    header = b64urlJson(h);
+    payload = b64urlJson(p);
+  } catch {
+    throw new TokenInvalidError("the token's header or payload is not valid base64url JSON");
+  }
+  // Pin the algorithm before touching key material — accepting whatever the
+  // header claims is the classic none/HS-confusion hole.
+  if (header.alg !== "RS256") {
+    throw new TokenInvalidError(`this server only accepts RS256 tokens; this one declares alg=${safeText(header.alg, 24)}`);
+  }
+  if (typeof header.kid !== "string") {
+    throw new TokenInvalidError("the token header carries no kid, so its signing key cannot be identified");
+  }
+  const key = await keyFor(cfg, header.kid);
+  const ok = cryptoVerify(
+    "RSA-SHA256",
+    Buffer.from(`${h}.${p}`),
+    key,
+    Buffer.from(sig, "base64url")
+  );
+  if (!ok) {
+    throw new TokenInvalidError(
+      `the token's signature does not verify against the published key (kid=${safeText(header.kid)})`);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof payload.exp !== "number") {
+    throw new TokenInvalidError("the token carries no exp claim, so it can never be considered valid");
+  }
+  if (payload.exp + CLOCK_TOLERANCE_SEC < now) {
+    // The age matters: seconds past expiry is a refresh that did not happen,
+    // while days past is a stored token being replayed. Different fixes.
+    throw new TokenInvalidError(
+      `the token expired ${now - payload.exp}s ago (tolerance ${CLOCK_TOLERANCE_SEC}s)`);
+  }
+  if (payload.iss !== cfg.authorizationServer) {
+    throw new TokenInvalidError(
+      `the token was issued by ${safeText(payload.iss)}, but this server only accepts tokens from ${cfg.authorizationServer}`);
+  }
+  // fosite emits aud as an array (granted audience, single value by AS policy).
+  const aud: unknown[] = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+  if (!aud.includes(cfg.resource)) {
+    // Byte-for-byte per RFC 8707, so this fires on a stray trailing slash —
+    // which is invisible unless both values are printed side by side.
+    throw new TokenInvalidError(
+      `the token is bound to audience [${aud.map((a) => safeText(a)).join(", ")}], ` +
+      `but this resource is ${cfg.resource}`);
+  }
+  const scopes: unknown[] = Array.isArray(payload.scp) ? payload.scp : [];
+  if (!scopes.includes("mcp:tools")) {
+    throw new TokenInvalidError(
+      `the token is missing the mcp:tools scope (it has [${scopes.map((s) => safeText(s, 32)).join(", ")}]); ` +
+      `re-authorize and grant it`);
+  }
+  if (typeof payload.grant_id !== "string" || payload.grant_id === "") {
+    throw new TokenInvalidError("the token carries no grant_id, so no API key can be resolved from it");
+  }
+  return { grantId: payload.grant_id, subject: typeof payload.sub === "string" ? payload.sub : undefined };
+}
+
+// ---- Grant → key resolution --------------------------------------------------
+
+const resolveCache = new Map<string, { apiKey: string; expiresAt: number }>();
+/**
+ * In-flight resolutions, keyed by grant.
+ *
+ * Without this, a cold cache turns a burst into a stampede: measured, eight
+ * simultaneous calls on one grant produced eight resolve-key requests. That is
+ * exactly the shape a real client makes — an agent firing several tool calls
+ * at once right after authorizing — so the worst moment for the dependency is
+ * also its most likely one. The JWKS path already coalesced; this one did not.
+ */
+const resolveInFlight = new Map<string, Promise<string>>();
+
+export function resolveGrant(cfg: OAuthRsConfig, grantId: string): Promise<string> {
+  const cached = resolveCache.get(grantId);
+  if (cached && cached.expiresAt > Date.now()) return Promise.resolve(cached.apiKey);
+  const inFlight = resolveInFlight.get(grantId);
+  if (inFlight) return inFlight;
+  const p = resolveGrantOnce(cfg, grantId).finally(() => resolveInFlight.delete(grantId));
+  resolveInFlight.set(grantId, p);
+  return p;
+}
+
+async function resolveGrantOnce(cfg: OAuthRsConfig, grantId: string): Promise<string> {
+  if (!cfg.resolveUrl || !cfg.resolveToken) {
+    // A deployment error, not a transient one: this instance advertises OAuth
+    // but cannot complete it. Naming the variables is the whole fix.
+    throw new OAuthBackendError(
+      "this deployment advertises OAuth but cannot exchange grants for keys " +
+      "(OCTEN_OAUTH_RESOLVE_URL / OCTEN_OAUTH_RESOLVE_TOKEN are not both set)");
+  }
+  let res: Awaited<ReturnType<typeof undiciFetch>>;
+  try {
+    res = await undiciFetch(cfg.resolveUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Octen-Service-Token": cfg.resolveToken,
+      },
+      body: JSON.stringify({ grant_id: grantId }),
+      signal: AbortSignal.timeout(RESOLVE_TIMEOUT_MS),
+      // This call sits on the hot path for every OAuth tool call; the shared
+      // dispatcher is what keeps its socket alive between them.
+      dispatcher,
+    });
+  } catch (e) {
+    throw new OAuthBackendError(
+      `could not reach the grant-resolution service: ${fetchFailureReason(e, RESOLVE_TIMEOUT_MS)}`);
+  }
+  if (res.status !== 200) {
+    // 401 here is our own service token, not the caller's credential — worth
+    // separating, because otherwise it reads as the user's token being wrong
+    // and sends them round a re-authorization loop that cannot help.
+    throw new OAuthBackendError(
+      res.status === 401 || res.status === 403
+        ? `the grant-resolution service rejected this server's own service token (HTTP ${res.status})`
+        : `the grant-resolution service answered HTTP ${res.status}`);
+  }
+  let body: { active?: boolean; api_key?: string };
+  try {
+    body = (await res.json()) as typeof body;
+  } catch (e) {
+    throw new OAuthBackendError(
+      `the grant-resolution service's response could not be read: ${fetchFailureReason(e, RESOLVE_TIMEOUT_MS)}`);
+  }
+  if (!body.active || typeof body.api_key !== "string" || body.api_key === "") {
+    // The grant was revoked (or never existed): a *token* problem — the
+    // client must re-authorize, so this is 401 territory, not 503.
+    resolveCache.delete(grantId);
+    throw new TokenInvalidError(
+      "the authorization behind this token is no longer active — it was revoked, " +
+      "or the API key it was bound to was deleted; re-authorize to continue");
+  }
+  if (resolveCache.size >= RESOLVE_CACHE_MAX) resolveCache.clear();
+  resolveCache.set(grantId, { apiKey: body.api_key, expiresAt: Date.now() + RESOLVE_TTL_MS });
+  return body.api_key;
+}
+
+/** Full RS-side path: verify, then exchange. Errors are typed for the 401/503 split. */
+export async function apiKeyFromAccessToken(cfg: OAuthRsConfig, token: string): Promise<string> {
+  const { grantId } = await verifyAccessToken(cfg, token);
+  const apiKey = await resolveGrant(cfg, grantId);
+  logEvent("oauth_resolved", { grant_prefix: grantId.slice(0, 8) },
+    `access token verified, grant ${grantId.slice(0, 8)}… resolved`);
+  return apiKey;
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -13,7 +13,7 @@
  * note `meta` sits at the TOP level here (sibling of `data`), not under `data`.
  */
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
-import { postJson, OctenHttpError, bodyReadFailure } from "./http.js";
+import { postJson, OctenHttpError, bodyReadFailure, missingKeyMessage, type HandlerContext } from "./http.js";
 
 const API_KEY = process.env.OCTEN_API_KEY;
 
@@ -40,7 +40,7 @@ const BROAD_SEARCH_TIMEOUT_MAX_SEC = 300;
 export const searchTool: Tool = {
   name: "search",
   description:
-    `Search the live web and return ranked results (title, url, snippet) — fast, fresh, real-time web search for one focused lookup. Set \`topic\` to \`news\` for news-focused results. Pass \`highlight\` to get a ranked snippet per result, or \`full_content\` to pull the cleaned page body inline (heavier — costs more context). Narrow with domain / text include-exclude filters, a \`language\` filter (ISO 639-1 codes), and a time window (published/crawled \`start_time\`/\`end_time\`, or a relative \`time_range\`). Set \`include_images\` / \`include_videos\` to return media URLs per result.
+    `Search the live web and return ranked results (title, url, snippet) — fast, fresh, real-time web search for one focused lookup. Set \`topic\` to \`news\` for news-focused results. Pass \`highlight\` to get a ranked snippet per result, or \`full_content\` to pull the cleaned page body inline (heavier — costs more context). Narrow with domain / text include-exclude filters, a \`language\` filter (ISO 639-1 codes), and a time window (published/crawled \`start_time\`/\`end_time\`, or a relative \`time_range\`). Set \`include_images\` to return image URLs per result.
 
 USE FOR a single focused lookup: one fact, one entity, one document. If the question spans several independent subtopics, load and use \`broad_search\` instead — a sequence of search calls is slower and gives worse coverage than one fan-out. To read a page you already have the URL for, use \`extract\`.
 
@@ -70,15 +70,15 @@ keywords: web search, search the web, look up, find, check, fact, current inform
       },
       include_domains: {
         type: "array",
-        items: { type: "string", maxLength: 30 },
-        maxItems: 1000,
-        description: "Only return results from these domains (e.g. 'arxiv.org'). Max 1000, each ≤30 chars.",
+        items: { type: "string", maxLength: 60 },
+        maxItems: 1200,
+        description: "Only return results from these domains (e.g. 'arxiv.org'). Max 1200, each ≤60 chars.",
       },
       exclude_domains: {
         type: "array",
-        items: { type: "string", maxLength: 30 },
-        maxItems: 150,
-        description: "Drop results from these domains. Max 150, each ≤30 chars.",
+        items: { type: "string", maxLength: 60 },
+        maxItems: 1200,
+        description: "Drop results from these domains. Max 1200, each ≤60 chars.",
       },
       include_text: {
         type: "array",
@@ -172,11 +172,6 @@ keywords: web search, search the web, look up, find, check, fact, current inform
         default: false,
         description: "Return image URLs (and a cover image) found on each result page.",
       },
-      include_videos: {
-        type: "boolean",
-        default: false,
-        description: "Return video URLs found on each result page.",
-      },
       timeout: {
         type: "integer",
         minimum: 1,
@@ -242,22 +237,24 @@ interface SearchArgs {
   highlight?: HighlightOptions;
   full_content?: FullContentOptions;
   include_images?: boolean;
-  include_videos?: boolean;
   timeout?: number;
 }
 
 /** Handler — POSTs to Octen Search and reshapes the response for the LLM. */
-export async function handleSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+export async function handleSearch(rawArgs: Record<string, unknown>, ctx?: HandlerContext): Promise<CallToolResult> {
   const args = rawArgs as unknown as SearchArgs;
 
   if (typeof args.query !== "string" || args.query.trim().length === 0) {
     return errorResult("`query` must be a non-empty string");
   }
-  if (!API_KEY) {
-    return errorResult(
-      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
-      "and add it to your MCP client config (see README)."
-    );
+  // When a transport supplies ctx, it is authoritative — no env fallback. The
+  // stdio entry resolves the env key into ctx itself; falling back here would
+  // let an unauthenticated HTTP caller silently ride the deployment's own
+  // credential. The bare fallback exists only for direct in-process callers
+  // (the unit suites) that invoke handlers without a transport.
+  const apiKey = ctx ? ctx.apiKey : API_KEY;
+  if (!apiKey) {
+    return errorResult(missingKeyMessage(ctx));
   }
 
   // `timeout` is an HTTP-client concern, not part of the search payload.
@@ -272,6 +269,7 @@ export async function handleSearch(rawArgs: Record<string, unknown>): Promise<Ca
   let resp: Response;
   try {
     resp = await postJson({
+      apiKey,
       path: "/search",
       body,
       label: "Octen Search",
@@ -320,9 +318,9 @@ export async function handleSearch(rawArgs: Record<string, unknown>): Promise<Ca
 }
 
 /** Handler — news search. Forces `topic=news`, ignoring any caller-supplied topic. */
-export async function handleNewsSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+export async function handleNewsSearch(rawArgs: Record<string, unknown>, ctx?: HandlerContext): Promise<CallToolResult> {
   const { topic: _ignored, ...rest } = rawArgs ?? {};
-  return handleSearch({ ...rest, topic: "news" });
+  return handleSearch({ ...rest, topic: "news" }, ctx);
 }
 
 /**
@@ -399,17 +397,20 @@ interface BroadSearchArgs extends SearchArgs {
 }
 
 /** Handler — POSTs to Octen Broad Search and reshapes the grouped response. */
-export async function handleBroadSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+export async function handleBroadSearch(rawArgs: Record<string, unknown>, ctx?: HandlerContext): Promise<CallToolResult> {
   const args = rawArgs as unknown as BroadSearchArgs;
 
   if (typeof args.query !== "string" || args.query.trim().length === 0) {
     return errorResult("`query` must be a non-empty string");
   }
-  if (!API_KEY) {
-    return errorResult(
-      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
-      "and add it to your MCP client config (see README)."
-    );
+  // When a transport supplies ctx, it is authoritative — no env fallback. The
+  // stdio entry resolves the env key into ctx itself; falling back here would
+  // let an unauthenticated HTTP caller silently ride the deployment's own
+  // credential. The bare fallback exists only for direct in-process callers
+  // (the unit suites) that invoke handlers without a transport.
+  const apiKey = ctx ? ctx.apiKey : API_KEY;
+  if (!apiKey) {
+    return errorResult(missingKeyMessage(ctx));
   }
 
   // `timeout` is an HTTP-client concern; `query` and `max_queries` stay at the
@@ -427,6 +428,7 @@ export async function handleBroadSearch(rawArgs: Record<string, unknown>): Promi
   let resp: Response;
   try {
     resp = await postJson({
+      apiKey,
       path: "/broad-search",
       body,
       label: "Octen Broad Search",
@@ -481,6 +483,46 @@ export async function handleBroadSearch(rawArgs: Record<string, unknown>): Promi
   return { content: [{ type: "text", text }] };
 }
 
+/**
+ * How many media URLs to print per result before summarising the rest.
+ *
+ * A caller who sets `include_images` wants the URLs, so printing only a count
+ * — which is what this did — returns nothing they can act on. But the arrays
+ * are not small: one measured result carried 101 images, and pasting all of
+ * them into a model's context costs more than the answer is worth. So: list a
+ * usable number, then say plainly how many were left out. Truncating silently
+ * would trade one useless output for another.
+ */
+const MEDIA_LIST_LIMIT = 10;
+
+/**
+ * One media entry as `url — description`.
+ *
+ * The caption is not decoration: on news results it carries what was
+ * photographed, where, when, and the photographer's credit, which is often
+ * more of what the caller wanted than the URL itself. Dropping it leaves a
+ * bare link the model cannot say anything about.
+ */
+export function formatMediaItem(m: { url: string; description?: unknown }): string {
+  const caption = typeof m.description === "string" ? m.description.trim() : "";
+  return caption === "" ? m.url : `${m.url} — ${caption}`;
+}
+
+/** `[{url, description}]` → markdown lines, capped and honest about the cap. */
+export function formatMediaList(label: string, items: unknown): string[] {
+  if (!Array.isArray(items) || items.length === 0) return [];
+  const entries = items
+    .filter((m): m is { url: string; description?: unknown } =>
+      typeof (m as { url?: unknown })?.url === "string" && (m as { url: string }).url !== "");
+  if (entries.length === 0) return [];
+
+  const shown = entries.slice(0, MEDIA_LIST_LIMIT);
+  const head = entries.length > shown.length
+    ? `**${label}:** ${entries.length} — first ${shown.length}:`
+    : `**${label}:** ${entries.length}`;
+  return [head, ...shown.map((m) => `- ${formatMediaItem(m)}`)];
+}
+
 function formatResult(r: any, idx: number, total: number): string {
   const lines: string[] = [`## Result ${idx}/${total}: ${r.title ?? "(untitled)"}`];
   if (r.url) lines.push(r.url);
@@ -488,9 +530,16 @@ function formatResult(r: any, idx: number, total: number): string {
   if (r.time_published) lines.push(`**Published:** ${r.time_published}`);
   if (r.time_last_crawled) lines.push(`**Last crawled:** ${r.time_last_crawled}`);
   if (r.favicon) lines.push(`**Favicon:** ${r.favicon}`);
-  if (r.cover_image) lines.push(`**Cover image:** ${r.cover_image}`);
-  if (Array.isArray(r.images) && r.images.length) lines.push(`**Images:** ${r.images.length}`);
-  if (Array.isArray(r.videos) && r.videos.length) lines.push(`**Videos:** ${r.videos.length}`);
+  // `cover_image` is `{url, description}`, not a string — interpolating the
+  // object printed `**Cover image:** [object Object]` on every result that had
+  // one. `extract.ts` had this right; this copy did not.
+  if (r.cover_image?.url) lines.push(`**Cover image:** ${formatMediaItem(r.cover_image)}`);
+  lines.push(...formatMediaList("Images", r.images));
+  // No `include_videos` parameter — the API reference does not document one for
+  // search, so we do not advertise it. The renderer stays: if a response ever
+  // carries `videos` anyway, dropping them silently is the bug this block was
+  // written to fix.
+  lines.push(...formatMediaList("Videos", r.videos));
 
   if (typeof r.highlight === "string" && r.highlight.length > 0) {
     lines.push(`\n### Highlight\n${r.highlight}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,237 @@
+/**
+ * Transport-agnostic assembly of the Octen MCP server.
+ *
+ * Everything about the server that is NOT "how bytes arrive" lives here — the
+ * tool roster, dispatch, per-call observability, Beta gating — so the stdio
+ * entry (`index.ts`) and the HTTP entry (`httpServer.ts`) cannot drift apart.
+ * The two entries differ in exactly one meaningful way, expressed as
+ * {@link CreateServerOptions.getApiKey}: stdio serves one user whose key lives
+ * in the environment; HTTP serves many keys, one per request.
+ */
+import { createRequire } from "node:module";
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { extractTool, handleExtract } from "./extract.js";
+import {
+  searchTool,
+  handleSearch,
+  newsSearchTool,
+  handleNewsSearch,
+  broadSearchTool,
+  handleBroadSearch,
+} from "./search.js";
+import { imageSearchTool, handleImageSearch } from "./imageSearch.js";
+import { videoSearchTool, handleVideoSearch } from "./videoSearch.js";
+import { logEvent, type HandlerContext } from "./http.js";
+import { validateArgs } from "./validate.js";
+
+// Read the version from package.json rather than restating it here — the
+// hardcoded copy silently drifted (0.3.6 while the package shipped as 0.3.7),
+// which made the version a client reported useless for triaging bug reports.
+const require = createRequire(import.meta.url);
+export const { version: VERSION } = require("../package.json") as { version: string };
+
+// Beta tools (image_search, video_search) are invite-only. A host can hide them
+// from tool discovery so agents never surface capabilities most accounts can't
+// use. This is a process-level switch: under stdio that means per-install;
+// under HTTP it gates the whole deployment. The tool list is deliberately NOT
+// per-key: `initialize` and `tools/list` are
+// unauthenticated, so the list must be computable without a credential — a key
+// without Beta access gets a clear 403 envelope error at call time instead.
+const betaFlag = (process.env.OCTEN_ENABLE_BETA_TOOLS ?? "").trim().toLowerCase();
+const BETA_TOOLS_ENABLED = !["false", "0", "off", "no"].includes(betaFlag);
+const BETA_TOOL_NAMES = new Set(["image_search", "video_search"]);
+
+const allTools = [
+  searchTool,
+  newsSearchTool,
+  broadSearchTool,
+  extractTool,
+  imageSearchTool,
+  videoSearchTool,
+];
+
+const enabledTools = allTools.filter((t) => BETA_TOOLS_ENABLED || !BETA_TOOL_NAMES.has(t.name));
+
+/**
+ * Every tool this process can serve, after the Beta switch.
+ *
+ * Exported so the transport can reject an unknown name in a per-connection
+ * tool selection *before* building a server, and say which names are real. A
+ * selection must never be a way around the Beta switch, so a Beta tool that is
+ * switched off is absent here and cannot be selected.
+ */
+export const AVAILABLE_TOOL_NAMES: readonly string[] = enabledTools.map((t) => t.name);
+
+/**
+ * Every tool name this build knows, Beta switch ignored.
+ *
+ * Exists only so a refusal can tell the two cases apart. Answering
+ * `?tools=image_search` on a Beta-off deployment with "Unknown tool name" is
+ * false — the name is real, it is this deployment that does not serve it — and
+ * it sends whoever reads the message hunting for a typo that is not there.
+ * Both are still refused; only the sentence differs.
+ */
+export const KNOWN_TOOL_NAMES: readonly string[] = allTools.map((t) => t.name);
+
+// Monotonic per process, shared across per-request server instances in HTTP
+// mode, so "call #N" in the trace stays a process-wide sequence.
+let callSeq = 0;
+
+export interface CreateServerOptions {
+  /**
+   * Resolves the credential for one call. Bound per server instance: stdio
+   * builds one server whose key comes from the environment; the HTTP entry
+   * builds a server per request with the header key closed over — module
+   * state would hand one tenant's key to another's request.
+   */
+  getApiKey: () => string | undefined;
+  transport: "stdio" | "http";
+  /**
+   * Restrict this server instance to these tool names; omitted means all.
+   *
+   * Per instance rather than per process, because the HTTP transport builds a
+   * fresh server for every request and can therefore honour a different
+   * selection per connection. The saving is context, not capability: a client
+   * loads every advertised tool's full schema into the model's context, so a
+   * caller who only wants `search` should not have to carry the description of
+   * five tools it will never call.
+   *
+   * Callers are expected to have validated the names against
+   * {@link AVAILABLE_TOOL_NAMES} — this only filters.
+   */
+  tools?: readonly string[];
+}
+
+export function createOctenServer(opts: CreateServerOptions): Server {
+  const server = new Server(
+    {
+      name: "octen-mcp",
+      version: VERSION,
+      // Branding surface for connector directories and client UIs — the
+      // fields those directories read. Purely declarative.
+      title: "Octen",
+      websiteUrl: "https://octen.ai",
+      icons: [{ src: "https://octen.ai/favicon.ico", mimeType: "image/x-icon" }],
+    },
+    {
+      capabilities: {
+        tools: {}, // we expose tools (not resources or prompts in v1)
+      },
+    }
+  );
+
+  const selected = opts.tools
+    ? enabledTools.filter((t) => opts.tools!.includes(t.name))
+    : enabledTools;
+  const selectedNames = new Set(selected.map((t) => t.name));
+  const byName = new Map(selected.map((t) => [t.name, t]));
+
+  // 1. List available tools — clients call this first to discover what we offer.
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: selected,
+  }));
+
+  // 2. Dispatch tool calls.
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args } = req.params;
+
+    // Stamp the moment the call reached this process, before any of our work.
+    //
+    // This is the measurement that settles who owns a slow call. Subtract this
+    // timestamp from the one the MCP client recorded when it issued the tool
+    // call, and the difference is time spent entirely outside octen-mcp — in
+    // the host, or in whatever relays between them. Without it, a client-side
+    // stopwatch attributes that delay to us by default, because we are the
+    // last thing in the chain that reports anything at all.
+    const seq = ++callSeq;
+    const receivedAt = Date.now();
+    logEvent("call_received", { seq, tool: name, transport: opts.transport },
+      `call #${seq} received tool=${name} transport=${opts.transport}`);
+
+    // In a `finally`, not around each return: the beta-disabled and
+    // unknown-tool branches return without touching the switch, and a handler
+    // that throws (anything not an OctenHttpError is deliberately rethrown)
+    // skipped it entirely. Each of those logged "received" and never
+    // "returning", so scanning the trace for calls that never came back — the
+    // reason the pair exists — produced false hangs.
+    const finish = () =>
+      logEvent("call_returning", { seq, tool: name, handler_ms: Date.now() - receivedAt },
+        `call #${seq} returning tool=${name} handler_total=${Date.now() - receivedAt}ms`);
+
+    const ctx: HandlerContext = { apiKey: opts.getApiKey(), transport: opts.transport };
+
+    try {
+      if (!BETA_TOOLS_ENABLED && BETA_TOOL_NAMES.has(name)) {
+        return {
+          isError: true,
+          content: [
+            { type: "text", text: `Tool "${name}" is disabled: Beta tools are turned off via OCTEN_ENABLE_BETA_TOOLS.` },
+          ],
+        };
+      }
+
+      // Enforced on the call path too, not only in the listing. A selection
+      // that merely hid tools would be decoration: nothing stops a client from
+      // calling a name it was never shown, and a caller who narrowed the set
+      // for cost or blast-radius reasons would be getting neither.
+      if (!selectedNames.has(name)) {
+        return {
+          isError: true,
+          content: [{
+            type: "text",
+            text: opts.tools && AVAILABLE_TOOL_NAMES.includes(name)
+              ? `Tool "${name}" exists but is not enabled for this connection ` +
+                `(enabled: ${[...selectedNames].join(", ")}).`
+              : `Unknown tool: ${name}`,
+          }],
+        };
+      }
+
+      // Against the tool's own advertised schema, not a copy of its rules —
+      // a duplicated rule set drifts the first time someone edits a schema,
+      // and drifts silently. The SDK does not do this for us: measured,
+      // `count: 999999` against `maximum: 100` was forwarded upstream intact.
+      const schemaError = validateArgs(byName.get(name)?.inputSchema, args ?? {});
+      if (schemaError) {
+        return { isError: true, content: [{ type: "text", text: `Invalid arguments for \`${name}\`: ${schemaError}` }] };
+      }
+
+      switch (name) {
+        case "search":
+          return await handleSearch(args ?? {}, ctx);
+        case "news_search":
+          return await handleNewsSearch(args ?? {}, ctx);
+        case "broad_search":
+          return await handleBroadSearch(args ?? {}, ctx);
+        case "extract":
+          return await handleExtract(args ?? {}, ctx);
+        case "image_search":
+          return await handleImageSearch(args ?? {}, ctx);
+        case "video_search":
+          return await handleVideoSearch(args ?? {}, ctx);
+        /* c8 ignore next 8 -- unreachable: the membership check above rejects
+           any name not in this switch. Kept so that adding a tool to the
+           roster without a case here fails loudly rather than falling through
+           to whatever the last case happened to be. */
+        default:
+          // MCP convention: return an error result, don't throw.
+          return {
+            isError: true,
+            content: [
+              { type: "text", text: `Tool "${name}" is advertised but not wired up — this is a bug in octen-mcp.` },
+            ],
+          };
+      }
+    } finally {
+      finish();
+    }
+  });
+
+  return server;
+}

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,171 @@
+/**
+ * Validation of tool arguments against the tool's own advertised schema.
+ *
+ * The MCP SDK does not enforce `inputSchema` — measured: `count: 999999`
+ * against a schema declaring `maximum: 100`, a 5000-character `query` against
+ * `maxLength: 500`, and a 5000-entry array against `maxItems: 1000` were all
+ * forwarded to the upstream API verbatim. So every constraint we publish was
+ * advertising, not a contract. Two costs. An agent that reads the schema and
+ * respects it gets no benefit over one that ignores it, and when it does get
+ * something wrong the answer comes back as an opaque upstream 400 instead of a
+ * sentence naming the field. And whatever the caller sends is relayed onward,
+ * which makes this server a pass-through for arbitrary JSON.
+ *
+ * The validator reads the same `inputSchema` object that is sent to clients,
+ * never a copy of its rules. A duplicated rule set drifts the first time
+ * someone edits a schema, and drifts silently — the failure would be a limit
+ * that is enforced at a value nobody advertised.
+ *
+ * It implements exactly the vocabulary those schemas use and nothing else, and
+ * {@link unsupportedKeywords} exists so a test can assert that stays true: a
+ * keyword the validator does not know would otherwise be ignored, turning a
+ * published constraint back into advertising without anyone noticing.
+ */
+
+/** JSON Schema keywords this validator enforces. */
+const ENFORCED = new Set([
+  "type", "enum", "minimum", "maximum", "maxLength", "minLength",
+  "minItems", "maxItems", "required", "properties", "items",
+]);
+
+/** Keywords that carry no constraint — safe to ignore. */
+const ANNOTATIONS = new Set(["description", "default", "title", "examples"]);
+
+/**
+ * Every keyword in `schema` that this validator neither enforces nor knows to
+ * be an annotation. Used by the suite to fail when a schema starts declaring
+ * something the validator would silently skip.
+ */
+export function unsupportedKeywords(schema: unknown): string[] {
+  const found = new Set<string>();
+  const walk = (s: unknown): void => {
+    if (!s || typeof s !== "object") return;
+    const o = s as Record<string, unknown>;
+    for (const k of Object.keys(o)) {
+      if (!ENFORCED.has(k) && !ANNOTATIONS.has(k)) found.add(k);
+    }
+    if (o.properties && typeof o.properties === "object") {
+      for (const v of Object.values(o.properties as Record<string, unknown>)) walk(v);
+    }
+    if (o.items) walk(o.items);
+  };
+  walk(schema);
+  return [...found];
+}
+
+interface Schema {
+  type?: string;
+  enum?: unknown[];
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  minItems?: number;
+  maxItems?: number;
+  required?: string[];
+  properties?: Record<string, Schema>;
+  items?: Schema;
+}
+
+/** How a value reads back in an error message, without pasting a huge payload. */
+function show(v: unknown): string {
+  if (typeof v === "string") {
+    return v.length > 40 ? `a ${v.length}-character string` : JSON.stringify(v);
+  }
+  if (Array.isArray(v)) return `an array of ${v.length}`;
+  if (v === null) return "null";
+  if (typeof v === "object") return "an object";
+  return JSON.stringify(v);
+}
+
+function typeMatches(type: string, v: unknown): boolean {
+  switch (type) {
+    case "string": return typeof v === "string";
+    // `integer` is not `number`: a fractional count is a caller bug worth
+    // naming, not something to round on the way past.
+    case "integer": return typeof v === "number" && Number.isInteger(v);
+    case "number": return typeof v === "number" && Number.isFinite(v);
+    case "boolean": return typeof v === "boolean";
+    case "array": return Array.isArray(v);
+    case "object": return typeof v === "object" && v !== null && !Array.isArray(v);
+    default: return true;
+  }
+}
+
+/**
+ * Check `value` against `schema`. Returns a message naming the first problem,
+ * or null when it passes.
+ *
+ * One problem rather than all of them: the message goes to a model deciding
+ * what to do next, and the first concrete thing to fix beats a list.
+ */
+export function validateArgs(schema: unknown, value: unknown, path = ""): string | null {
+  if (!schema || typeof schema !== "object") return null;
+  const s = schema as Schema;
+  const at = path === "" ? "" : ` for \`${path}\``;
+
+  if (s.type && !typeMatches(s.type, value)) {
+    return `Expected ${s.type}${at}, got ${show(value)}.`;
+  }
+  if (s.enum && !s.enum.includes(value as never)) {
+    return `Invalid value${at}: ${show(value)}. Allowed: ${s.enum.map((e) => JSON.stringify(e)).join(", ")}.`;
+  }
+  if (typeof value === "number") {
+    if (s.minimum !== undefined && value < s.minimum) {
+      return `Value${at} must be at least ${s.minimum}, got ${value}.`;
+    }
+    if (s.maximum !== undefined && value > s.maximum) {
+      return `Value${at} must be at most ${s.maximum}, got ${value}.`;
+    }
+  }
+  if (typeof value === "string") {
+    if (s.minLength !== undefined && value.length < s.minLength) {
+      return `Value${at} must be at least ${s.minLength} characters, got ${value.length}.`;
+    }
+    if (s.maxLength !== undefined && value.length > s.maxLength) {
+      return `Value${at} must be at most ${s.maxLength} characters, got ${value.length}.`;
+    }
+  }
+  if (Array.isArray(value)) {
+    if (s.minItems !== undefined && value.length < s.minItems) {
+      return `Array${at} must have at least ${s.minItems} item(s), got ${value.length}.`;
+    }
+    if (s.maxItems !== undefined && value.length > s.maxItems) {
+      return `Array${at} must have at most ${s.maxItems} item(s), got ${value.length}.`;
+    }
+    if (s.items) {
+      for (let i = 0; i < value.length; i++) {
+        const err = validateArgs(s.items, value[i], `${path}[${i}]`);
+        if (err) return err;
+      }
+    }
+  }
+  if (s.properties && typeof value === "object" && value !== null && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    for (const name of s.required ?? []) {
+      if (obj[name] === undefined) return `Missing required parameter \`${path ? `${path}.` : ""}${name}\`.`;
+    }
+    // Undeclared parameters are refused rather than relayed. The properties
+    // list *is* the published interface, and anything outside it would
+    // otherwise be forwarded to the upstream API unexamined — a pass-through
+    // for arbitrary JSON. Naming the accepted parameters turns a typo into one
+    // round trip instead of a silently ignored argument.
+    for (const name of Object.keys(obj)) {
+      // `Object.hasOwn`, never `in`: `in` walks the prototype chain, so
+      // `toString`, `valueOf`, `hasOwnProperty` and `constructor` all read as
+      // declared parameters of any schema. Measured against the first version
+      // of this check — three of them sailed through and were relayed upstream,
+      // which is the exact hole this function exists to close.
+      if (!Object.hasOwn(s.properties, name)) {
+        return `Unknown parameter \`${path ? `${path}.` : ""}${name}\`. ` +
+          `Accepted: ${Object.keys(s.properties).join(", ")}.`;
+      }
+    }
+    for (const [name, sub] of Object.entries(s.properties)) {
+      if (obj[name] === undefined) continue;
+      const err = validateArgs(sub, obj[name], path ? `${path}.${name}` : name);
+      if (err) return err;
+    }
+  }
+  return null;
+}

--- a/src/videoSearch.ts
+++ b/src/videoSearch.ts
@@ -13,7 +13,7 @@
  */
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { formatMeta, errorResult } from "./search.js";
-import { postJson, OctenHttpError, bodyReadFailure } from "./http.js";
+import { postJson, OctenHttpError, bodyReadFailure, missingKeyMessage, type HandlerContext } from "./http.js";
 
 /** Client-side ceiling when the caller passes no `timeout`. */
 const VIDEO_SEARCH_TIMEOUT_SEC = 30;
@@ -85,17 +85,20 @@ interface VideoSearchArgs {
 }
 
 /** Handler — POSTs to Octen Video Search and reshapes the response for the LLM. */
-export async function handleVideoSearch(rawArgs: Record<string, unknown>): Promise<CallToolResult> {
+export async function handleVideoSearch(rawArgs: Record<string, unknown>, ctx?: HandlerContext): Promise<CallToolResult> {
   const args = rawArgs as unknown as VideoSearchArgs;
 
   if (typeof args.query !== "string" || args.query.trim().length === 0) {
     return errorResult("`query` must be a non-empty string");
   }
-  if (!API_KEY) {
-    return errorResult(
-      "OCTEN_API_KEY env var is not set. Get a key at https://octen.ai " +
-      "and add it to your MCP client config (see README)."
-    );
+  // When a transport supplies ctx, it is authoritative — no env fallback. The
+  // stdio entry resolves the env key into ctx itself; falling back here would
+  // let an unauthenticated HTTP caller silently ride the deployment's own
+  // credential. The bare fallback exists only for direct in-process callers
+  // (the unit suites) that invoke handlers without a transport.
+  const apiKey = ctx ? ctx.apiKey : API_KEY;
+  if (!apiKey) {
+    return errorResult(missingKeyMessage(ctx));
   }
 
   // `timeout` is an HTTP-client concern; `query` is flattened into `inputs` (text only).
@@ -112,6 +115,7 @@ export async function handleVideoSearch(rawArgs: Record<string, unknown>): Promi
   let resp: Response;
   try {
     resp = await postJson({
+      apiKey,
       path: "/video-search",
       body,
       label: "Octen Video Search",

--- a/test/adversarial.test.mjs
+++ b/test/adversarial.test.mjs
@@ -1,0 +1,1690 @@
+/**
+ * Adversarial suite: hostile input and mid-flight network faults against the
+ * remote HTTP transport.
+ *
+ * The distinction that organises this file is *who* can reach a code path.
+ * `initialize` and `tools/list` are unauthenticated by design, and the OAuth
+ * path parses an unverified token header before any signature check — so a
+ * large amount of logic runs for anyone who can open a socket. Every test here
+ * therefore ends the same way: the process must still be alive and serving.
+ * A wrong answer is one failed request; a dead process is the whole
+ * deployment, and with `replicas: 1` in pre that is a total outage from a
+ * single curl.
+ *
+ * These are regressions for real defects, each reproduced against the built
+ * server before the fix:
+ *
+ *  - a `kid` containing CRLF reached `res.writeHead` through the
+ *    `WWW-Authenticate` challenge and killed the process (`ERR_INVALID_CHAR`
+ *    thrown out of an async handler = unhandled rejection = exit);
+ *  - 10 unauthenticated requests with made-up `kid`s produced 11 JWKS fetches
+ *    against our own authorization server;
+ *  - a malformed `OCTEN_MCP_RESOURCE` passed startup and every health probe,
+ *    then killed the process on the first `?login` — a pod that is healthy
+ *    until someone uses it.
+ *
+ * The network-fault half exists because the OAuth path adds two synchronous
+ * dependencies (JWKS, resolve-key) to what used to be a single upstream call.
+ * Each can fail at a different stage — connect, headers, mid-body — and the
+ * required behaviour differs per stage: a token problem is 401 so clients
+ * refresh, an infrastructure problem is 503 so they retry instead of burning
+ * their refresh flow on our outage.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import net from "node:net";
+import { spawn } from "node:child_process";
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+
+import { startHttp, SERVER, waitForStderr } from "./helpers.mjs";
+
+const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const KID = "test-kid-1";
+const RESOURCE = "https://mcp.octen.example/mcp";
+
+const b64url = (buf) => Buffer.from(buf).toString("base64url");
+
+function mint({ kid = KID, alg = "RS256", sig: forcedSig, ...claims }) {
+  const header = b64url(JSON.stringify({ alg, kid, typ: "JWT" }));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = b64url(JSON.stringify({ iat: now, exp: now + 3600, ...claims }));
+  if (forcedSig !== undefined) return `${header}.${payload}.${forcedSig}`;
+  const sig = cryptoSign("sha256", Buffer.from(`${header}.${payload}`), privateKey);
+  return `${header}.${payload}.${b64url(sig)}`;
+}
+
+/**
+ * Authorization server with a fault switch per endpoint.
+ *
+ * `mode` values map to the stages a real dependency fails at, which is the
+ * axis that matters: `hang` never answers (dead peer holding the socket),
+ * `reset` sends headers then tears the connection down mid-body (the shape
+ * undici reports as a bare `TypeError: terminated`), `garbage` and `http500`
+ * answer promptly but unusably.
+ */
+function startAs({ serviceToken = "svc-secret", jwks = "ok", resolve = "ok", jwksDelayMs = 0 } = {}) {
+  const hits = { jwks: 0, resolve: 0 };
+  const held = [];
+
+  const respond = (res, mode, okBody) => {
+    switch (mode) {
+      case "hang":
+        held.push(res); // never answered; socket stays open
+        return;
+      case "garbage":
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("<html>not json at all</html>");
+        return;
+      case "http500":
+        res.writeHead(500);
+        res.end("boom");
+        return;
+      case "reset":
+        // Headers promise far more body than we send, then the socket dies.
+        res.writeHead(200, { "Content-Type": "application/json", "Content-Length": "5000" });
+        res.write('{"keys":[');
+        res.socket.destroy();
+        return;
+      default:
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(okBody));
+    }
+  };
+
+  const srv = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/api/oauth/jwks") {
+      hits.jwks++;
+      const jwk = publicKey.export({ format: "jwk" });
+      const usable = jwks === "no-rsa"
+        ? [{ kty: "EC", kid: KID, crv: "P-256", x: "a", y: "b" }]   // parseable JSON, unusable key
+        : [{ ...jwk, kid: KID, use: "sig", alg: "RS256" }];
+      const send = () => respond(res, jwks === "no-rsa" ? "ok" : jwks, { keys: usable });
+      if (jwksDelayMs) setTimeout(send, jwksDelayMs); else send();
+      return;
+    }
+    if (req.method === "POST" && req.url === "/internal/oauth/resolve-key") {
+      hits.resolve++;
+      if (req.headers["x-octen-service-token"] !== serviceToken) { res.writeHead(401); res.end(); return; }
+      let body = "";
+      req.on("data", (d) => (body += d));
+      req.on("end", () => {
+        const { grant_id } = JSON.parse(body);
+        respond(res, resolve, { active: true, api_key: `resolved-${grant_id}`, account_type: "user", account_id: "u1" });
+      });
+      return;
+    }
+    res.writeHead(404); res.end();
+  });
+  return new Promise((r) => srv.listen(0, () => r({
+    port: srv.address().port, hits,
+    issuer: `http://127.0.0.1:${srv.address().port}`,
+    close: () => { for (const res of held) res.socket?.destroy(); srv.close(); },
+  })));
+}
+
+/** Upstream Octen API with the same fault switch, for post-auth stages. */
+function startFaultyUpstream(mode = "ok") {
+  // Records the credential it was handed. Several tests turn on *what* reached
+  // the upstream, not merely whether the call succeeded — forwarding a bearer
+  // token here as if it were an API key is itself the defect.
+  const seenKeys = [];
+  const srv = http.createServer((req, res) => {
+    seenKeys.push(req.headers["x-api-key"]);
+    if (mode === "reset") {
+      res.writeHead(200, { "Content-Type": "application/json", "Content-Length": "9999" });
+      res.write('{"code":0,"data":{"resu');
+      res.socket.destroy();
+      return;
+    }
+    if (mode === "garbage") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("<html>gateway error page</html>");
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ code: 0, data: { results: [] }, meta: {} }));
+  });
+  return new Promise((r) => srv.listen(0, () =>
+    r({ port: srv.address().port, seenKeys, close: () => srv.close() })));
+}
+
+async function startStack({ as: asOpts = {}, upstream = "ok", env = {} } = {}) {
+  const as = await startAs(asOpts);
+  const up = await startFaultyUpstream(upstream);
+  const srv = await startHttp({
+    OCTEN_API_URL: `http://127.0.0.1:${up.port}`,
+    OCTEN_OAUTH_AUTHORIZATION_SERVER: as.issuer,
+    OCTEN_MCP_RESOURCE: RESOURCE,
+    OCTEN_OAUTH_RESOLVE_URL: `${as.issuer}/internal/oauth/resolve-key`,
+    OCTEN_OAUTH_RESOLVE_TOKEN: "svc-secret",
+    ...env,
+  });
+  return { as, up, srv, stop: () => { srv.stop(); up.close(); as.close(); } };
+}
+
+function claims(as, extra = {}) {
+  return { iss: as.issuer, aud: [RESOURCE], scp: ["mcp:tools"], sub: "u1", grant_id: "g1", ...extra };
+}
+
+async function bearerCall(port, token, { id = 2, timeoutMs = 20000 } = {}) {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id, method: "tools/call", params: { name: "search", arguments: { query: "q" } } }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const text = await res.text();
+  const data = text.split("\n").filter((l) => l.startsWith("data: ")).pop();
+  return {
+    status: res.status,
+    wwwAuth: res.headers.get("www-authenticate"),
+    msg: data ? JSON.parse(data.slice(6)) : (text ? JSON.parse(text) : undefined),
+  };
+}
+
+/**
+ * The assertion every test in this file ends with. Checks the process directly
+ * rather than only the response: a handler that crashes *after* writing its
+ * response still takes the deployment down, and a status-code-only assertion
+ * would pass right through it.
+ */
+async function assertAlive(srv, note) {
+  assert.equal(srv.child.exitCode, null,
+    `the server process died — ${note}. One request must never be able to do this.\n${srv.stderr()}`);
+  const h = await fetch(`http://127.0.0.1:${srv.port}/healthz`, { signal: AbortSignal.timeout(3000) });
+  assert.equal(h.status, 200, `server stopped serving after ${note}`);
+}
+
+// ---- Hostile token headers reaching response headers -------------------------
+
+test("a kid carrying CRLF cannot inject a header or kill the process", async () => {
+  const stack = await startStack();
+  try {
+    // Reproduces the original kill exactly: unknown kid → TokenInvalidError
+    // whose message was interpolated verbatim into WWW-Authenticate, where the
+    // CRLF made `res.writeHead` throw ERR_INVALID_CHAR out of the handler.
+    const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${mint({ kid: "x\r\nInjected-Header: pwned", ...claims(stack.as) })}`,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "search", arguments: { query: "q" } } }),
+    });
+    await res.text();
+    assert.equal(res.status, 401);
+    // The header must exist as ONE inert value. Asserting the text is absent
+    // would be the wrong bar: sanitising keeps the characters and drops the
+    // line break, which is what makes the payload inert — a smuggled header
+    // needs the CRLF, not the words.
+    assert.equal(res.headers.get("injected-header"), null, "the payload became a real header");
+    assert.doesNotMatch(res.headers.get("www-authenticate"), /[\r\n]/,
+      "no line break may survive into a header value");
+    assert.match(res.headers.get("www-authenticate"), /^Bearer error="invalid_token"/);
+    await assertAlive(stack.srv, "kid with CRLF");
+  } finally { stack.stop(); }
+});
+
+test("a kid carrying quotes and backslashes leaves the challenge parseable", async () => {
+  const stack = await startStack();
+  try {
+    const r = await bearerCall(stack.srv.port, mint({ kid: 'a"b\\c"', ...claims(stack.as) }));
+    assert.equal(r.status, 401);
+    // Exactly the quotes RFC 6750 puts there: error=, error_description=,
+    // resource_metadata=. An unescaped quote from the kid would add more and
+    // truncate the challenge where a client stops parsing.
+    assert.equal((r.wwwAuth.match(/"/g) ?? []).length, 6,
+      `challenge has unbalanced quoting: ${r.wwwAuth}`);
+    assert.match(r.wwwAuth, /resource_metadata="https:\/\/mcp\.octen\.example\/\.well-known\/oauth-protected-resource\/mcp"$/);
+    await assertAlive(stack.srv, "kid with quotes");
+  } finally { stack.stop(); }
+});
+
+test("an oversized kid is truncated rather than echoed into the header", async () => {
+  const stack = await startStack();
+  try {
+    // 2KB: large enough that echoing it would bloat every challenge, small
+    // enough to get past Node's own request-header ceiling and actually reach
+    // the sanitiser. Without truncation the response header mirrors whatever
+    // the attacker sent, on a path that needs no credential.
+    const r = await bearerCall(stack.srv.port, mint({ kid: "A".repeat(2_000), ...claims(stack.as) }));
+    assert.equal(r.status, 401);
+    assert.ok(r.wwwAuth.length < 500, `challenge grew to ${r.wwwAuth.length} bytes from a hostile kid`);
+
+    // Past Node's ceiling the request never reaches our code at all — 431
+    // rather than a crash, which is the outcome that matters here.
+    const huge = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${mint({ kid: "A".repeat(40_000), ...claims(stack.as) })}`,
+      },
+      body: "{}",
+    }).then((r) => r.status, () => "refused");
+    assert.ok(huge === 431 || huge === "refused", `unexpected answer to a 40KB header: ${huge}`);
+    await assertAlive(stack.srv, "oversized kid");
+  } finally { stack.stop(); }
+});
+
+test("hostile kids do not poison later legitimate calls", async () => {
+  const stack = await startStack();
+  try {
+    for (const kid of ["\r\n\r\n", '"', "\u0000\u0007", " ", "../../etc/passwd", "🙂".repeat(100)]) {
+      const r = await bearerCall(stack.srv.port, mint({ kid, ...claims(stack.as) }));
+      assert.equal(r.status, 401, `kid ${JSON.stringify(kid).slice(0, 40)} should be a clean 401`);
+    }
+    // The point of the loop: the process survived all of it AND still works.
+    const ok = await bearerCall(stack.srv.port, mint(claims(stack.as)), { id: 99 });
+    assert.equal(ok.status, 200, "a valid token must still work after the hostile ones");
+    await assertAlive(stack.srv, "a burst of hostile kids");
+  } finally { stack.stop(); }
+});
+
+// ---- Amplification against our own authorization server ----------------------
+
+test("unknown kids cannot be used to amplify requests against the JWKS endpoint", async () => {
+  const stack = await startStack();
+  try {
+    await bearerCall(stack.srv.port, mint(claims(stack.as))); // prime
+    const before = stack.as.hits.jwks;
+    for (let i = 0; i < 10; i++) {
+      const r = await bearerCall(stack.srv.port, mint({ kid: `made-up-${i}`, ...claims(stack.as) }));
+      assert.equal(r.status, 401);
+    }
+    // Measured at 10 extra fetches before the cooldown existed — one per
+    // unauthenticated request, straight through to our own AS.
+    assert.ok(stack.as.hits.jwks - before <= 1,
+      `10 unauthenticated requests caused ${stack.as.hits.jwks - before} JWKS fetches`);
+    await assertAlive(stack.srv, "unknown-kid burst");
+  } finally { stack.stop(); }
+});
+
+test("a concurrent burst of unknown kids collapses into one JWKS fetch", async () => {
+  // Cooldown at 0 so the rate limiter cannot be what passes this test — the
+  // in-flight coalescing has to carry it alone. The AS is also made slow on
+  // purpose: against a localhost JWKS answering in ~2ms the twelve requests
+  // never actually overlap, so they each start their own fetch and the test
+  // passes or fails on scheduling luck rather than on the behaviour.
+  const stack = await startStack({
+    as: { jwksDelayMs: 300 },
+    env: { OCTEN_JWKS_REFETCH_COOLDOWN_MS: "0" },
+  });
+  try {
+    await bearerCall(stack.srv.port, mint(claims(stack.as))); // prime
+    const before = stack.as.hits.jwks;
+    await Promise.all(Array.from({ length: 12 }, (_, i) =>
+      bearerCall(stack.srv.port, mint({ kid: `concurrent-${i}`, ...claims(stack.as) }), { id: 100 + i })));
+    assert.equal(stack.as.hits.jwks - before, 1,
+      `12 simultaneous misses caused ${stack.as.hits.jwks - before} JWKS fetches`);
+    await assertAlive(stack.srv, "concurrent unknown-kid burst");
+  } finally { stack.stop(); }
+});
+
+// ---- Signature and algorithm attacks ----------------------------------------
+
+test("alg=none and HS256 confusion are rejected without consulting the AS", async () => {
+  const stack = await startStack();
+  try {
+    await bearerCall(stack.srv.port, mint(claims(stack.as))); // prime, so a fetch below is visible
+    const before = stack.as.hits.jwks + stack.as.hits.resolve;
+    for (const alg of ["none", "HS256", "RS512", ""]) {
+      const r = await bearerCall(stack.srv.port, mint({ alg, sig: "", ...claims(stack.as) }));
+      assert.notEqual(r.status, 503, `alg=${alg} must not be treated as a backend problem`);
+      assert.notEqual(stack.up, undefined);
+    }
+    assert.equal(stack.as.hits.jwks + stack.as.hits.resolve, before,
+      "a token pinned to an unsupported algorithm must not reach any AS endpoint");
+    await assertAlive(stack.srv, "algorithm confusion attempts");
+  } finally { stack.stop(); }
+});
+
+test("anything token-shaped is judged as a token, not retried as an API key", async () => {
+  // The credential forms share one header, so something has to decide which
+  // path a value takes. Deciding on "can we verify it" put every JWT this
+  // server cannot verify into the API key path: measured, `alg: none`, an
+  // HS256 token and one missing `kid` were each forwarded verbatim to the
+  // upstream as a key and answered 200 with a tool-level "Invalid API Key".
+  //
+  // Two failures in one. A client holding a bearer token needs 401 + challenge
+  // to know it must re-authorize — a tool error reads as a backend fault to
+  // retry, so it never does. And a whole bearer token, possibly minted for a
+  // different audience, ends up in our gateway's logs as if it were a key.
+  const stack = await startStack();
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const tokenShaped = {
+      "forged signature": mint({ ...claims(stack.as), sig: b64url(Buffer.alloc(256, 9)) }),
+      "expired": mint({ ...claims(stack.as), exp: now - 7200 }),
+      // Built by hand: passing `kid: undefined` to mint() just triggers its
+      // default parameter, which silently puts the kid back.
+      "no kid in header": (() => {
+        const h = b64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+        const pl = b64url(JSON.stringify({ ...claims(stack.as), exp: now + 3600 }));
+        return `${h}.${pl}.${b64url(cryptoSign("sha256", Buffer.from(`${h}.${pl}`), privateKey))}`;
+      })(),
+      "alg=HS256": `${b64url(JSON.stringify({ alg: "HS256", kid: KID }))}.${b64url(JSON.stringify(claims(stack.as)))}.AAAA`,
+      "alg=none": `${b64url(JSON.stringify({ alg: "none", kid: KID }))}.${b64url(JSON.stringify(claims(stack.as)))}.`,
+    };
+    for (const [label, token] of Object.entries(tokenShaped)) {
+      const before = stack.up.seenKeys.length;
+      const r = await bearerCall(stack.srv.port, token);
+      assert.equal(r.status, 401, `${label} was not judged as a token`);
+      assert.match(r.wwwAuth ?? "", /^Bearer /, `${label} carried no challenge to act on`);
+      assert.equal(stack.up.seenKeys.length, before,
+        `${label} was forwarded upstream as an API key`);
+    }
+
+    // The other side of the line: a value that is not token-shaped stays a
+    // key, and a wrong key still earns the tool-level "check your key" error.
+    const r = await bearerCall(stack.srv.port, "sk-octen-not-a-jwt-at-all");
+    assert.equal(r.status, 200, "a bare key must not be answered with an OAuth challenge");
+    assert.deepEqual(stack.up.seenKeys, ["sk-octen-not-a-jwt-at-all"]);
+    await assertAlive(stack.srv, "credential routing");
+  } finally { stack.stop(); }
+});
+
+test("a token with a valid header but a forged signature never reaches resolve-key", async () => {
+  const stack = await startStack();
+  try {
+    const before = stack.as.hits.resolve;
+    const r = await bearerCall(stack.srv.port, mint({ sig: b64url(Buffer.alloc(256, 7)), ...claims(stack.as) }));
+    assert.equal(r.status, 401);
+    assert.equal(stack.as.hits.resolve, before,
+      "signature verification must gate the grant exchange, not follow it");
+    await assertAlive(stack.srv, "forged signature");
+  } finally { stack.stop(); }
+});
+
+// ---- Network faults, by stage ------------------------------------------------
+
+test("JWKS endpoint answering 500 is a 503, not a 401", async () => {
+  const stack = await startStack({ as: { jwks: "http500" } });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    assert.equal(r.status, 503, "the token may be perfectly valid — a 401 would log the user out over our outage");
+    await assertAlive(stack.srv, "JWKS 500");
+  } finally { stack.stop(); }
+});
+
+test("JWKS endpoint returning non-JSON is a 503", async () => {
+  const stack = await startStack({ as: { jwks: "garbage" } });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    assert.equal(r.status, 503);
+    await assertAlive(stack.srv, "JWKS garbage body");
+  } finally { stack.stop(); }
+});
+
+test("JWKS connection dying mid-body is a 503, not a crash", async () => {
+  const stack = await startStack({ as: { jwks: "reset" } });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    assert.equal(r.status, 503);
+    await assertAlive(stack.srv, "JWKS reset mid-body");
+  } finally { stack.stop(); }
+});
+
+test("a JWKS endpoint that never answers is bounded, not a hung request", async () => {
+  const stack = await startStack({ as: { jwks: "hang" } });
+  try {
+    const started = Date.now();
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)), { timeoutMs: 15000 });
+    assert.equal(r.status, 503);
+    assert.ok(Date.now() - started < 12_000,
+      "a dead AS must fail fast; an unbounded wait is how one dependency takes every worker with it");
+    await assertAlive(stack.srv, "JWKS hang");
+  } finally { stack.stop(); }
+});
+
+test("resolve-key dying mid-body is a 503, and the bad answer is not cached", async () => {
+  const stack = await startStack({ as: { resolve: "reset" } });
+  try {
+    const r1 = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    assert.equal(r1.status, 503);
+    const after = stack.as.hits.resolve;
+    const r2 = await bearerCall(stack.srv.port, mint(claims(stack.as)), { id: 3 });
+    assert.equal(r2.status, 503);
+    assert.ok(stack.as.hits.resolve > after,
+      "a failed resolve must be retried, not cached — caching it would extend one blip into a 60s outage");
+    await assertAlive(stack.srv, "resolve-key reset");
+  } finally { stack.stop(); }
+});
+
+test("a resolve-key endpoint that never answers is bounded", async () => {
+  const stack = await startStack({ as: { resolve: "hang" } });
+  try {
+    const started = Date.now();
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)), { timeoutMs: 15000 });
+    assert.equal(r.status, 503);
+    assert.ok(Date.now() - started < 10_000, "resolve-key sits on the hot path; its timeout must be tight");
+    await assertAlive(stack.srv, "resolve-key hang");
+  } finally { stack.stop(); }
+});
+
+test("the upstream API dying mid-body after a valid token is a tool error, not a 5xx or a crash", async () => {
+  const stack = await startStack({ upstream: "reset" });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    // Authorization succeeded, so this is a tool-level failure: the transport
+    // must stay 200 and the error travel inside the result, or clients read it
+    // as an auth problem and re-authorize into the same wall.
+    assert.equal(r.status, 200);
+    assert.equal(r.msg.result.isError, true);
+    const text = r.msg.result.content[0].text;
+    // The named cause is the whole point of the shared HTTP layer: bare
+    // `fetch failed` / `code=UNKNOWN` is what made these tickets undiagnosable.
+    assert.match(text, /code=(UND_ERR_SOCKET|ECONNRESET|UND_ERR_RES_CONTENT_LENGTH_MISMATCH)|connection lost while reading the response body/,
+      `the failure must name a cause, got: ${text}`);
+    assert.doesNotMatch(text, /code=UNKNOWN|^Network error calling Octen Search: $/);
+    await assertAlive(stack.srv, "upstream reset mid-body");
+  } finally { stack.stop(); }
+});
+
+test("an upstream that answers 200 with an HTML error page is reported as non-JSON", async () => {
+  const stack = await startStack({ upstream: "garbage" });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    assert.equal(r.status, 200);
+    assert.equal(r.msg.result.isError, true);
+    // The gateway-returns-HTML case: a JSON parse error here used to surface as
+    // an unexplained failure, which reads as our bug rather than the edge's.
+    assert.match(r.msg.result.content[0].text, /non-JSON|HTML/i);
+    await assertAlive(stack.srv, "upstream HTML body");
+  } finally { stack.stop(); }
+});
+
+// ---- Malformed requests ------------------------------------------------------
+
+test("malformed and hostile request bodies are answered, never fatal", async () => {
+  const stack = await startStack();
+  try {
+    const bodies = [
+      "not json at all",
+      "",
+      "[]",
+      "null",
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "search" } }), // no arguments
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "../../admin" }),
+      `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":${"[".repeat(2000)}${"]".repeat(2000)}}`,
+    ];
+    for (const body of bodies) {
+      const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+        body,
+        signal: AbortSignal.timeout(10000),
+      });
+      assert.ok(res.status < 600, "some HTTP answer is required");
+      await res.text();
+    }
+    await assertAlive(stack.srv, "malformed bodies");
+  } finally { stack.stop(); }
+});
+
+test("a chunked body cannot slip past the size cap by declaring no length", async () => {
+  // The cap used to read Content-Length, which a chunked request simply does
+  // not send — so it applied only to clients that volunteered their size.
+  // Measured against the unfixed build: 75 MB accepted against a 1 MiB cap,
+  // resident memory 88 MB → 246 MB, on an endpoint that needs no credential
+  // and a container limited to 512 MiB.
+  const stack = await startStack({ env: { OCTEN_MCP_MAX_BODY: "65536", OCTEN_MCP_LOG: "json" } });
+  try {
+    const chunk = "x".repeat(16 * 1024);
+    const { status, sent, destroyed, sawReset } = await new Promise((resolve, reject) => {
+      const sock = net.connect(stack.srv.port, "127.0.0.1");
+      let resp = "", written = 0, settled = false, status = NaN, sawReset = false;
+      // The status line is read as soon as it arrives, but the verdict waits
+      // for `close` — the two facts under test are "413" and "the server hung
+      // up", and the second one is only observable once the peer's FIN lands.
+      // Reading `sock.destroyed` at the instant the response arrives reports
+      // false against a server that is closing correctly; an earlier version
+      // of this test failed exactly that way.
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        resolve({ status, sent: written, destroyed: sock.destroyed, sawReset });
+      };
+      sock.on("data", (d) => {
+        resp += d;
+        const m = resp.match(/^HTTP\/1\.1 (\d+)/);
+        if (m && Number.isNaN(status)) {
+          status = Number(m[1]);
+          // Bounded: if the server answers but leaves the socket open, that is
+          // the defect this asserts against, and it must not hang the suite.
+          setTimeout(finish, 1500);
+        }
+      });
+      // EPIPE/ECONNRESET here is the fix working — the server answered and hung
+      // up while we were still writing. Only an unexpected error fails.
+      sock.on("error", (e) => {
+        // A reset is the failure mode under test, not an incidental error: the
+        // server must drain the rest of the body and close gracefully, because
+        // resetting discards the 413 that was already written. Recorded rather
+        // than thrown so the assertion names it.
+        if (e.code === "ECONNRESET") { sawReset = true; return; }
+        if (e.code === "EPIPE") return;
+        reject(e);
+      });
+      sock.on("close", finish);
+      sock.on("connect", async () => {
+        // Credential present on purpose: without one the OAuth challenge
+        // answers first and the body cap is never exercised.
+        sock.write("POST /mcp HTTP/1.1\r\nHost: x\r\nContent-Type: application/json\r\n" +
+          "x-api-key: bare-key\r\n" +
+          "Accept: application/json, text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n");
+        // Stops once the server answers, which is what any real client does:
+        // it reads its socket. A client that instead floods without ever
+        // reading may miss the 413 no matter what the server does — the drain
+        // budget is finite, and closing while the peer is still sending resets
+        // the connection, which discards the response. That case is covered
+        // below by what it can actually promise: the server stays healthy.
+        // Just past the cap, not a flood. Writing megabytes from the test's
+        // own event loop starves its socket reads, and the test then fails for
+        // its own reasons rather than the server's — this spent several runs
+        // measuring that. The flooding case is covered separately below, by
+        // the only thing it can promise: the server survives it.
+        for (let i = 0; i < 24 && !sock.destroyed && resp === ""; i++) {
+          sock.write(`${chunk.length.toString(16)}\r\n${chunk}\r\n`);
+          written += chunk.length;
+          if (i % 5 === 0) await new Promise((r) => setImmediate(r));
+        }
+        // Terminate the request properly. Without this the server never sees
+        // `end`, falls back to its drain cutoff, and closes with a reset — and
+        // a reset drops whatever the client has not read yet, which under a
+        // loaded event loop is the response itself. A real client finishes its
+        // request; a test that does not was measuring its own impatience.
+        if (!sock.destroyed) sock.write("0\r\n\r\n");
+        setTimeout(finish, 2500);
+      });
+    });
+    assert.equal(status, 413, `chunked body was not capped (sent ${sent} bytes)`);
+    assert.ok(destroyed, "the connection must not be left open after a 413");
+    // Deterministic counterpart to the reset check below: whether the client
+    // wins the race to read the 413 before a reset is up to the kernel, but
+    // whether the server drained at all is not.
+    // Either drain outcome counts: the client's chunked terminator often
+    // cannot be delivered at all, because `Connection: close` makes Node
+    // half-close as soon as the 413 goes out — so the drain usually ends at
+    // its cutoff rather than at `end`. What must not happen is no drain.
+    // Waited for, not sampled: the drain finishes once the peer stops sending,
+    // which is strictly after the 413 this test already has in hand. Reading
+    // stderr at that instant asks for a line the server has no reason to have
+    // written yet — green locally, red on every CI runner.
+    const drainLog = await waitForStderr(stack.srv, /"event":"body_drain(ed|_cutoff)"/);
+    assert.match(drainLog, /"event":"body_drain(ed|_cutoff)"/,
+      `the server never drained the rejected body:\n${drainLog}`);
+    assert.equal(sawReset, false,
+      "the connection was reset — a reset discards the 413 that was already written, " +
+      "which is how an oversized request turns back into an unexplained failure");
+    // And the server is unharmed: still serving, still correct.
+    const after = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json", Accept: "application/json, text/event-stream",
+        "x-api-key": "bare-key",   // OAuth is on here; an anonymous probe is a 401 by design
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    assert.equal(after.status, 200);
+    await after.text();
+    await assertAlive(stack.srv, "oversized chunked body");
+
+    // The flooder: writes without ever reading, and is abandoned. Nothing can
+    // promise it a 413, but it must not cost the server anything either.
+    await new Promise((resolve) => {
+      const flood = net.connect(stack.srv.port, "127.0.0.1");
+      flood.on("error", () => {});
+      flood.on("connect", async () => {
+        flood.write("POST /mcp HTTP/1.1\r\nHost: x\r\nContent-Type: application/json\r\n" +
+          "x-api-key: bare-key\r\nAccept: application/json, text/event-stream\r\n" +
+          "Transfer-Encoding: chunked\r\n\r\n");
+        for (let i = 0; i < 600 && !flood.destroyed; i++) {
+          flood.write(`${chunk.length.toString(16)}\r\n${chunk}\r\n`);
+          if (i % 20 === 0) await new Promise((r) => setImmediate(r));
+        }
+        flood.destroy();
+        resolve();
+      });
+    });
+    const healthy = await fetch(`http://127.0.0.1:${stack.srv.port}/healthz`);
+    assert.equal(healthy.status, 200, "a flooding client took the server with it");
+    await healthy.text();
+    await assertAlive(stack.srv, "abandoned flood");
+  } finally { stack.stop(); }
+});
+
+test("an unparseable body is a JSON-RPC parse error that quotes the parser", async () => {
+  const stack = await startStack();
+  try {
+    const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json", Accept: "application/json, text/event-stream",
+        "x-api-key": "bare-key",   // else the OAuth challenge answers before the parser
+      },
+      body: "{ definitely not json",
+    });
+    const body = await res.json();
+    assert.equal(body.error.code, -32700, "JSON-RPC reserves -32700 for parse errors");
+    assertDiagnostic(body.error.message, /JSON/);
+    await assertAlive(stack.srv, "unparseable body");
+  } finally { stack.stop(); }
+});
+
+test("a client that disconnects mid-request does not leak the drain counter", async () => {
+  const stack = await startStack({ as: { resolve: "hang" } });
+  try {
+    for (let i = 0; i < 5; i++) {
+      const ac = new AbortController();
+      const p = fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: i, method: "tools/list" }),
+        signal: ac.signal,
+      }).catch(() => {});
+      setTimeout(() => ac.abort(), 20);
+      await p;
+    }
+    // If aborted requests left inFlight above zero, SIGTERM would sit through
+    // the whole drain budget and be SIGKILLed instead of exiting cleanly.
+    stack.srv.child.kill("SIGTERM");
+    const code = await Promise.race([
+      stack.srv.exited,
+      new Promise((r) => setTimeout(() => r("timeout"), 8000)),
+    ]);
+    assert.equal(code, 0, "drain did not complete after aborted requests — in-flight accounting leaked");
+  } finally { stack.up.close(); stack.as.close(); }
+});
+
+test("many ordinary bodies cannot exhaust memory the way one huge one cannot", async () => {
+  // The per-request cap and this budget answer different attacks. With the
+  // per-request cap at 6 MiB and no aggregate, forty concurrent 5 MB bodies
+  // measured 772 MB resident against a 768 MiB container — an OOM reachable
+  // by anyone holding a key, with no single request breaking a rule.
+  const stack = await startStack({ env: { OCTEN_MCP_MAX_INFLIGHT_BODY: "2097152", OCTEN_MCP_LOG: "json" } });
+  try {
+    // Padded through `image_data` rather than a stray top-level field: this is
+    // the payload the budget exists for, and it is a *valid* call, so the
+    // recovery leg below can actually succeed. An earlier version padded a
+    // field the SDK rejects, so every request 400'd — the 503 assertion still
+    // passed, while the "budget was released" leg could never have.
+    const body = JSON.stringify({
+      jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: "image_search", arguments: { image_data: "y".repeat(900 * 1024) } },
+    });
+    const codes = {};
+    const rs = await Promise.allSettled(Array.from({ length: 12 }, () =>
+      fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+        body, signal: AbortSignal.timeout(20000),
+      }).then((r) => r.status)));
+    for (const r of rs) { const k = r.status === "fulfilled" ? r.value : "err"; codes[k] = (codes[k] ?? 0) + 1; }
+
+    assert.ok((codes[503] ?? 0) > 0,
+      `no request was shed under a 2 MiB budget with 12 concurrent ~0.9 MiB bodies: ${JSON.stringify(codes)}`);
+    const budgetLog = await waitForStderr(stack.srv, /"event":"body_budget_exceeded"/);
+    assert.match(budgetLog, /"event":"body_budget_exceeded"/,
+      `no budget-exceeded event was logged:\n${budgetLog}`);
+
+    // Shedding, not failing: the refusal must be retryable and say so, because
+    // the caller has nothing to fix.
+    const shed = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+      body,
+    }).then(async (r) => ({ status: r.status, retry: r.headers.get("retry-after"), text: await r.text() }))
+      .catch(() => null);
+    if (shed?.status === 503) {
+      assert.equal(shed.retry, "1");
+      assert.match(shed.text, /at capacity/);
+      assert.match(shed.text, /OCTEN_MCP_MAX_INFLIGHT_BODY/, "name the knob that raises it");
+    }
+
+    // And the budget is released, not leaked. The follow-up has to be the same
+    // size as the burst: a small one fits in whatever the leak left over, so
+    // it passes either way and proves nothing.
+    await new Promise((r) => setTimeout(r, 1500));
+    const after = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+      body, signal: AbortSignal.timeout(20000),
+    });
+    await after.text();
+    assert.equal(after.status, 200,
+      "a body the same size as the burst was refused after it drained — the budget leaked");
+    await assertAlive(stack.srv, "in-flight body budget");
+  } finally { stack.stop(); }
+});
+
+// ---- Configuration that must fail loudly, at startup -------------------------
+
+/** Spawn the server directly; resolve { code, stderr } once it exits. */
+function spawnServer(env) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [SERVER], {
+      env: { ...process.env, PORT: "0", HTTPS_PROXY: "", https_proxy: "", ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let err = "";
+    child.stderr.on("data", (d) => (err += d));
+    child.on("exit", (code) => resolve({ code, stderr: err }));
+    setTimeout(() => { child.kill(); resolve({ code: "still-running", stderr: err }); }, 4000);
+  });
+}
+
+test("a malformed resource URL stops the process at startup, not at first use", async () => {
+  for (const bad of ["mcp.octen.ai/mcp", "://nope", "ftp://mcp.octen.ai/mcp", "  "]) {
+    const { code, stderr } = await spawnServer({
+      OCTEN_OAUTH_AUTHORIZATION_SERVER: "https://auth.octen.example",
+      OCTEN_MCP_RESOURCE: bad,
+    });
+    if (bad.trim() === "") {
+      // Blank simply leaves the OAuth surface off — that is a valid self-hosted
+      // configuration, not an error.
+      assert.equal(code, "still-running", `blank resource should start with OAuth disabled\n${stderr}`);
+      continue;
+    }
+    assert.equal(code, 1,
+      `${JSON.stringify(bad)} started anyway — it would pass every health probe and die on the first ?login\n${stderr}`);
+    assert.match(stderr, /OCTEN_MCP_RESOURCE/, "the log line must name the variable to fix");
+  }
+});
+
+test("a trailing slash on the authorization server stops at startup", async () => {
+  // Measured before this guard: the process started, every health probe
+  // passed, and then refused 100% of tokens — the JWKS URL became
+  // `…//api/oauth/jwks` and `iss` never matched, because no authorization
+  // server emits its issuer with a trailing slash. The rejection message did
+  // print both strings, but they differ by the one character nobody sees.
+  const { code, stderr } = await spawnServer({
+    OCTEN_OAUTH_AUTHORIZATION_SERVER: "https://auth.octen.example/",
+    OCTEN_MCP_RESOURCE: RESOURCE,
+  });
+  assert.equal(code, 1, `started anyway, and would refuse every token:\n${stderr}`);
+  assert.match(stderr, /OCTEN_OAUTH_AUTHORIZATION_SERVER/);
+  assert.match(stderr, /trailing slash|must not end with/);
+});
+
+test("a malformed authorization-server URL also stops at startup", async () => {
+  const { code, stderr } = await spawnServer({
+    OCTEN_OAUTH_AUTHORIZATION_SERVER: "auth.octen.ai",
+    OCTEN_MCP_RESOURCE: RESOURCE,
+  });
+  assert.equal(code, 1, stderr);
+  assert.match(stderr, /OCTEN_OAUTH_AUTHORIZATION_SERVER/);
+});
+
+// ---- Limits that must not be disableable by a typo ---------------------------
+
+test("a garbage body-size limit falls back instead of removing the limit", async () => {
+  const stack = await startStack({ env: { OCTEN_MCP_MAX_BODY: "one megabyte please" } });
+  try {
+    const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      // Must exceed the *fallback*, which is 6 MiB — that is the value under
+      // test. A payload sized against the old 1 MiB default would sail through
+      // and the assertion would silently stop checking anything.
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", pad: "x".repeat(7 * 1024 * 1024) }),
+      signal: AbortSignal.timeout(15000),
+    });
+    // NaN would have made every `>` comparison false and silently uncapped it.
+    assert.equal(res.status, 413, "the cap must survive an unparseable override");
+    // And it must fall back to *the* default, not merely to some cap: asserting
+    // only "413" passes against any value, so this stopped checking the
+    // fallback the moment the default changed.
+    assert.match(await res.text(), /exceeds 6291456 bytes/,
+      "the fallback must be the documented default, 6 MiB");
+    await assertAlive(stack.srv, "garbage OCTEN_MCP_MAX_BODY");
+  } finally { stack.stop(); }
+});
+
+test("the drain deadline is enforced when work is still in flight", async () => {
+  // With nothing in flight the loop exits on its first tick, so a broken
+  // deadline is invisible — an earlier version of this test killed an idle
+  // server and passed against a NaN budget. The hung upstream is what forces
+  // the deadline to be the thing that ends the drain.
+  const stack = await startStack({ as: { resolve: "hang" }, env: { OCTEN_DRAIN_TIMEOUT_MS: "600" } });
+  try {
+    const inflight = bearerCall(stack.srv.port, mint(claims(stack.as)), { timeoutMs: 20000 }).catch(() => {});
+    await new Promise((r) => setTimeout(r, 400));
+    const started = Date.now();
+    stack.srv.child.kill("SIGTERM");
+    const code = await Promise.race([
+      stack.srv.exited,
+      new Promise((r) => setTimeout(() => r("hung"), 8000)),
+    ]);
+    assert.equal(code, 1, "a drain that hits its deadline must exit non-zero, so the event is visible");
+    assert.ok(Date.now() - started < 5000, "the deadline was not honoured");
+    await inflight;
+  } finally { stack.up.close(); stack.as.close(); }
+});
+
+test("a garbage drain timeout falls back to the default budget, not to NaN", async () => {
+  // NaN makes `Date.now() > deadline` permanently false, so a drain with work
+  // in flight never ends and the pod is SIGKILLed at the end of its grace
+  // period instead of exiting. The effective budget is asserted from the log
+  // because it cannot be observed any other way — and observing it is the
+  // point: it must stay below terminationGracePeriodSeconds.
+  const stack = await startStack({
+    env: { OCTEN_DRAIN_TIMEOUT_MS: "soon", OCTEN_MCP_LOG: "json" },
+  });
+  try {
+    stack.srv.child.kill("SIGTERM");
+    const code = await Promise.race([
+      stack.srv.exited,
+      new Promise((r) => setTimeout(() => r("hung"), 8000)),
+    ]);
+    assert.equal(code, 0);
+    const line = stack.srv.stderr().split("\n").find((l) => l.includes('"drain_start"'));
+    assert.ok(line, `no drain_start line in:\n${stack.srv.stderr()}`);
+    assert.equal(JSON.parse(line).budget_ms, 310_000,
+      `unparseable budget was not replaced by the default: ${line}`);
+  } finally { stack.up.close(); stack.as.close(); }
+});
+
+
+
+
+// ---- Arguments are checked against the schema we publish ---------------------
+//
+// The SDK does not enforce `inputSchema`. Measured before this: `count: 999999`
+// against `maximum: 100`, a 5000-character `query` against `maxLength: 500`,
+// and a 5000-entry array against `maxItems: 1000` were each relayed to the
+// upstream API intact — every published constraint was advertising.
+
+test("every published schema uses only vocabulary the validator enforces", async () => {
+  // The guard that keeps the rest of this honest. A keyword the validator does
+  // not implement is silently ignored, which turns a published constraint back
+  // into advertising — and the schema author would have no way to notice. This
+  // reads the schemas as clients receive them, not as the source declares them.
+  const { unsupportedKeywords } = await import("../dist/validate.js");
+  const stack = await startStack();
+  try {
+    const r = await probe(stack.srv.port, "tools/list", { "x-api-key": "k" });
+    const tools = JSON.parse(r.text.split("\n").filter((l) => l.startsWith("data: ")).pop().slice(6)).result.tools;
+    assert.ok(tools.length >= 6);
+    for (const t of tools) {
+      assert.deepEqual(unsupportedKeywords(t.inputSchema), [],
+        `${t.name} declares a constraint the validator would ignore`);
+    }
+  } finally { stack.stop(); }
+});
+
+test("out-of-contract arguments are refused before anything is relayed upstream", async () => {
+  const stack = await startStack();
+  try {
+    const cases = [
+      [{ query: "q", count: 999999 }, /at most 100, got 999999/],
+      [{ query: "q", count: -5 }, /at least 1, got -5/],
+      [{ query: "q", count: "many" }, /Expected integer for `count`/],
+      [{ query: "q", count: 2.5 }, /Expected integer for `count`, got 2\.5/],
+      [{ query: "x".repeat(5000) }, /at most 500 characters, got 5000/],
+      [{ query: "q", topic: "gossip" }, /Allowed: "general", "news"/],
+      [{ query: "q", include_domains: Array.from({ length: 5000 }, (_, i) => `d${i}`) }, /at most 1200 item\(s\), got 5000/],
+      [{ query: "q", include_domains: ["x".repeat(99)] }, /include_domains\[0\]` must be at most 60/],
+      [{ query: "q", highlight: { enable: true, max_tokens: 999999 } }, /highlight\.max_tokens` must be at most 20000/],
+      [{ query: "q", highlight: { enable: "yes" } }, /Expected boolean for `highlight\.enable`/],
+      // The properties list is the published interface; anything outside it
+      // would otherwise be relayed to the upstream API unexamined.
+      [{ query: "q", evil: 1 }, /Unknown parameter `evil`/],
+      // Names that live on Object.prototype. A membership test written with
+      // `in` accepts every one of them as a declared parameter of any schema —
+      // measured, three sailed through and were relayed upstream.
+      [{ query: "q", toString: { x: 1 } }, /Unknown parameter `toString`/],
+      [{ query: "q", valueOf: { x: 1 } }, /Unknown parameter `valueOf`/],
+      [{ query: "q", hasOwnProperty: { x: 1 } }, /Unknown parameter `hasOwnProperty`/],
+      [{ count: 5 }, /Missing required parameter `query`/],
+    ];
+    for (const [args, expected] of cases) {
+      const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "search", arguments: args } }),
+      });
+      const text = await res.text();
+      const msg = JSON.parse(text.split("\n").filter((l) => l.startsWith("data: ")).pop().slice(6)).result.content[0].text;
+      assert.match(msg, expected, `wrong or missing rejection for ${JSON.stringify(args).slice(0, 60)}`);
+    }
+    // The point of doing this before dispatch: none of it reached the API.
+    assert.equal(stack.up.seenKeys.length, 0,
+      "an out-of-contract call was relayed upstream before being judged");
+    await assertAlive(stack.srv, "schema rejections");
+  } finally { stack.stop(); }
+});
+
+test("arguments at every declared boundary still pass", async () => {
+  // The reverse case, and the one that matters most: a validator that rejects
+  // everything would pass every test above. These are the exact edges the
+  // schemas publish, so each is legal by definition and must go through.
+  const stack = await startStack();
+  try {
+    const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "tools/call",
+        params: {
+          name: "search",
+          arguments: {
+            query: "x".repeat(500), count: 100, topic: "news",
+            include_domains: ["a.com"], highlight: { enable: true, max_tokens: 20000 },
+            full_content: { enable: false, max_tokens: 100000 }, language: ["zh", "ja"],
+            time_basis: "published", format: "markdown", safesearch: "off",
+            include_images: true, timeout: 60,
+          },
+        },
+      }),
+    });
+    const text = await res.text();
+    const result = JSON.parse(text.split("\n").filter((l) => l.startsWith("data: ")).pop().slice(6)).result;
+    assert.notEqual(result.isError, true, `boundary values were rejected: ${result.content?.[0]?.text}`);
+    assert.equal(stack.up.seenKeys.length, 1, "a legal call did not reach the upstream");
+  } finally { stack.stop(); }
+});
+
+test("each tool is validated against its own schema, not another's", async () => {
+  const stack = await startStack();
+  try {
+    // `news_search` publishes no `topic` — it is fixed to news — so passing one
+    // is out of contract even though `search` accepts it.
+    const news = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "news_search", arguments: { query: "q", topic: "general" } } }),
+    });
+    const msg = JSON.parse((await news.text()).split("\n").filter((l) => l.startsWith("data: ")).pop().slice(6))
+      .result.content[0].text;
+    assert.match(msg, /Unknown parameter `topic`/);
+
+    // And `extract` has a different required parameter entirely.
+    const extract = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "extract", arguments: { query: "q" } } }),
+    });
+    const emsg = JSON.parse((await extract.text()).split("\n").filter((l) => l.startsWith("data: ")).pop().slice(6))
+      .result.content[0].text;
+    assert.match(emsg, /Missing required parameter `urls`/);
+    assert.equal(stack.up.seenKeys.length, 0);
+  } finally { stack.stop(); }
+});
+
+// ---- URL-only clients, forced authorization, per-connection tool selection --
+//
+// Three affordances for clients that cannot do what a header-capable HTTP
+// client can. Each has a reverse case: passing the happy path proves the
+// feature exists, not that its guard works.
+
+test("a key can travel in the query string, but a header always wins", async () => {
+  // For clients that can only be handed a URL: Claude Desktop's mcpServers
+  // config is a stdio mechanism with nowhere to put a header, and mcp-remote
+  // takes `<url> [callback-port] [--debug]` with no header option.
+  const stack = await startStack({ env: { OCTEN_MCP_LOG: "json" } });
+  try {
+    const r = await probe(stack.srv.port, "tools/list", {}, "?octenApiKey=QUERYKEY123");
+    assert.equal(r.status, 200, "octenApiKey was not accepted as a credential");
+
+    // octenApiKey is the only query spelling that counts as a credential, and
+    // every plausible alternative has to keep failing. An extra accepted name
+    // is an extra string on the public interface for a compatibility win
+    // nobody asked for.
+    //
+    // tools/call rather than tools/list: without an authorization server
+    // tools/list needs no credential at all (see the note at the top of
+    // httpServer), so an assertion built on it would quietly stop testing
+    // anything under that deployment shape. tools/call demands a credential in
+    // both modes, so it is the method actually carrying this guard.
+    for (const spelling of ["apiKey", "api_key", "key", "token", "octen_api_key"]) {
+      const foreign = await probe(stack.srv.port, "tools/call",
+        { name: "search", arguments: { query: "q" } }, `?${spelling}=QUERYKEY123`);
+      assert.equal(foreign.status, 401,
+        `?${spelling}= must not be accepted as a credential; octenApiKey is the only one`);
+    }
+    // Reverse case: a header-capable client must never be downgraded to the
+    // query value, or two clients disagree about which key was billed.
+    const both = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp?octenApiKey=FROM-QUERY`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json", Accept: "application/json, text/event-stream",
+        "x-api-key": "FROM-HEADER",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "search", arguments: { query: "q" } } }),
+    });
+    assert.equal(both.status, 200);
+    await both.text();
+    assert.deepEqual(stack.up.seenKeys, ["FROM-HEADER"], "the query value overrode a header");
+
+    // A key in a URL reaches proxy logs and browser history — none of which we
+    // control. Ours we do.
+    assert.doesNotMatch(stack.srv.stderr(), /QUERYKEY123|FROM-QUERY/,
+      `a credential from the query string reached our own log:\n${stack.srv.stderr()}`);
+
+    // A flat 8-character prefix is the whole credential for anything shorter
+    // than that — measured, a 7-character key was logged in full — and a
+    // hand-typed key in a URL is exactly where short values show up.
+    const short = await probe(stack.srv.port, "tools/list", {}, "?octenApiKey=tinykey");
+    assert.equal(short.status, 200);
+    assert.doesNotMatch(stack.srv.stderr(), /tinykey/,
+      `a short credential was logged in full:\n${stack.srv.stderr()}`);
+    await assertAlive(stack.srv, "query credentials");
+  } finally { stack.stop(); }
+});
+
+test("forced authorization challenges even a request that carries a key", async () => {
+  // The one route from an already-configured API key to OAuth: with a key
+  // present the ordinary rule never challenges, so there is no way to switch.
+  const stack = await startStack();
+  try {
+    for (const [where, query, path] of [["/mcp/oauth", "", "/mcp/oauth"], ["?login", "?login", "/mcp"]]) {
+      const res = await fetch(`http://127.0.0.1:${stack.srv.port}${path}${query}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json", Accept: "application/json, text/event-stream",
+          "x-api-key": "a-perfectly-good-key",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      });
+      const body = await res.text();
+      assert.equal(res.status, 401, `${where} did not force the challenge`);
+      assert.match(res.headers.get("www-authenticate") ?? "", /resource_metadata=/);
+      // The message must not accuse a caller who did send a key of sending none.
+      assert.doesNotMatch(body, /No credential on this request/);
+      assert.match(body, /even when a key is supplied/);
+    }
+    // Reverse case: the ordinary endpoint must NOT challenge the same request,
+    // or forcing would just be the old behaviour with extra steps.
+    const plain = await probe(stack.srv.port, "tools/list", { "x-api-key": "a-perfectly-good-key" });
+    assert.equal(plain.status, 200);
+    await assertAlive(stack.srv, "forced authorization");
+  } finally { stack.stop(); }
+});
+
+test("the other routes are untouched by the new path", async () => {
+  const stack = await startStack();
+  try {
+    for (const path of ["/mcp", "/mcp/"]) {
+      const res = await fetch(`http://127.0.0.1:${stack.srv.port}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      });
+      assert.equal(res.status, 200, `${path} regressed`);
+      await res.text();
+    }
+    assert.equal((await fetch(`http://127.0.0.1:${stack.srv.port}/healthz`)).status, 200);
+    assert.equal((await fetch(`http://127.0.0.1:${stack.srv.port}/.well-known/oauth-protected-resource`)).status, 200);
+    assert.equal((await fetch(`http://127.0.0.1:${stack.srv.port}/.well-known/oauth-protected-resource/mcp`)).status, 200);
+    assert.equal((await fetch(`http://127.0.0.1:${stack.srv.port}/mcp/oauth/extra`)).status, 404);
+  } finally { stack.stop(); }
+});
+
+test("?tools narrows the roster, and the excluded tools really are gone", async () => {
+  const stack = await startStack();
+  try {
+    const list = async (q) => {
+      const r = await probe(stack.srv.port, "tools/list", { "x-api-key": "k" }, q);
+      assert.equal(r.status, 200, `tools/list failed for ${q || "(no filter)"}`);
+      return [...r.text.matchAll(/"name":"([a-z_]+)"/g)].map((m) => m[1]);
+    };
+    assert.equal((await list("")).length, 6);
+    assert.deepEqual(await list("?tools=search"), ["search"]);
+    assert.deepEqual(await list("?tools=search,extract"), ["search", "extract"]);
+    assert.deepEqual(await list("?tools=search,search"), ["search"], "duplicates must not advertise a tool twice");
+    assert.equal((await list("?tools=")).length, 6, "an empty value means no selection, not no tools");
+
+    // The reverse case that makes the feature real rather than decorative: a
+    // client can call a tool it was never shown, so filtering the list alone
+    // filters nothing.
+    const call = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp?tools=search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "extract", arguments: { urls: ["http://x"] } } }),
+    });
+    const text = await call.text();
+    assert.match(text, /"isError":true/, "an excluded tool was callable");
+    assert.match(text, /not enabled for this connection/);
+    assert.equal(stack.up.seenKeys.length, 0, "an excluded tool reached the upstream");
+    await assertAlive(stack.srv, "tool selection");
+  } finally { stack.stop(); }
+});
+
+test("an unknown or empty tool selection is refused, not silently narrowed", async () => {
+  // Silently dropping a misspelled name produces a connection that looks
+  // healthy and is missing a tool — and sends whoever debugs it to look at the
+  // tool rather than at the spelling in their URL.
+  const stack = await startStack();
+  try {
+    for (const q of ["?tools=serch", "?tools=search,nope", "?tools=,,,"]) {
+      const r = await probe(stack.srv.port, "tools/list", { "x-api-key": "k" }, q);
+      assert.equal(r.status, 400, `${q} was accepted`);
+      const body = JSON.parse(r.text);
+      assert.equal(body.error.code, -32602, "invalid params is the JSON-RPC code for this");
+      assert.match(body.error.message, /Available: search, news_search/,
+        `the refusal must list the real names: ${body.error.message}`);
+    }
+    await assertAlive(stack.srv, "invalid tool selection");
+  } finally { stack.stop(); }
+});
+
+test("a real tool the deployment does not serve is not called unknown", async () => {
+  // Refused either way — but "Unknown tool name: image_search" is false when
+  // the name is real and it is this deployment that does not serve it, and it
+  // sends whoever reads the message hunting for a typo that is not there.
+  const stack = await startStack({ env: { OCTEN_ENABLE_BETA_TOOLS: "false" } });
+  try {
+    const msg = async (q) => {
+      const r = await probe(stack.srv.port, "tools/list", { "x-api-key": "k" }, q);
+      assert.equal(r.status, 400, `${q} should be refused`);
+      return JSON.parse(r.text).error.message;
+    };
+
+    const disabled = await msg("?tools=image_search");
+    assert.match(disabled, /not enabled on this deployment/);
+    assert.match(disabled, /OCTEN_ENABLE_BETA_TOOLS/, "name the switch that is responsible");
+    assert.doesNotMatch(disabled, /Unknown tool name/, "the name is real; saying otherwise misdirects");
+
+    const typo = await msg("?tools=serch");
+    assert.match(typo, /Unknown tool name: "serch"/);
+    assert.doesNotMatch(typo, /not enabled/, "a typo is not a deployment setting");
+
+    // Both kinds at once: each must be described as what it is.
+    const mixed = await msg("?tools=serch,video_search");
+    assert.match(mixed, /Unknown tool name: "serch"/);
+    assert.match(mixed, /"video_search" is not enabled on this deployment/);
+
+    // Whatever the reason, the reader is told what they can actually ask for,
+    // and Beta tools are absent from that list on this deployment.
+    for (const m of [disabled, typo, mixed]) {
+      assert.match(m, /Available: search, news_search, broad_search, extract\./);
+      assert.doesNotMatch(m, /Available:[^.]*image_search/);
+    }
+  } finally { stack.stop(); }
+});
+
+test("a selection cannot re-enable a Beta tool that the switch turned off", async () => {
+  // Two independent switches. If a selection could reach past the Beta switch,
+  // the switch would be advisory — and the tool would 403 at call time instead,
+  // which is a much worse way to find out.
+  const stack = await startStack({ env: { OCTEN_ENABLE_BETA_TOOLS: "false" } });
+  try {
+    const all = await probe(stack.srv.port, "tools/list", { "x-api-key": "k" });
+    assert.equal([...all.text.matchAll(/"name":"([a-z_]+)"/g)].length, 4, "Beta tools should be absent");
+
+    const r = await probe(stack.srv.port, "tools/list", { "x-api-key": "k" }, "?tools=image_search");
+    assert.equal(r.status, 400, "a disabled Beta tool must read as a name that does not exist");
+    assert.doesNotMatch(JSON.parse(r.text).error.message, /image_search, video_search/,
+      "the available list must not advertise tools this process will not serve");
+  } finally { stack.stop(); }
+});
+
+// ---- Protocol surface: the shapes real clients and real pastes produce ------
+//
+// Each of these was probed against the built server rather than assumed. Two
+// were defects and are fixed; the rest are pinned here because they are the
+// contract a client depends on, and because a plausible "cleanup" could break
+// any of them without a single existing test noticing.
+
+test("a trailing slash on the endpoint is accepted, not 404", async () => {
+  // The commonest paste artifact in a URL a human copies into a client config.
+  // Answering 404 makes a working deployment look broken for a reason nobody
+  // inspects — it was a 404 before this.
+  const stack = await startStack();
+  try {
+    const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    assert.equal(res.status, 200);
+    await res.text();
+  } finally { stack.stop(); }
+});
+
+test("a burst on one grant makes a single resolve-key call", async () => {
+  // Measured before coalescing: eight simultaneous calls, eight resolve-key
+  // requests. That burst is what an agent firing several tools at once right
+  // after authorizing looks like — the dependency's worst moment is also its
+  // most likely one. The JWKS path already coalesced; this one did not.
+  const stack = await startStack();
+  try {
+    const token = mint(claims(stack.as, { grant_id: "burst" }));
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, i) => bearerCall(stack.srv.port, token, { id: 200 + i })));
+    assert.ok(results.every((r) => r.status === 200), "a coalesced burst must still succeed for everyone");
+    assert.equal(stack.as.hits.resolve, 1, `${stack.as.hits.resolve} resolve-key calls for one grant`);
+  } finally { stack.stop(); }
+});
+
+test("an Accept header missing text/event-stream is refused with the reason", async () => {
+  // A real trip-hazard: this 406 looks like an auth failure to anyone probing
+  // by hand, so the message has to say what is actually missing.
+  const stack = await startStack();
+  try {
+    const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json", "x-api-key": "k" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    assert.equal(res.status, 406);
+    const body = await res.text();
+    assert.match(body, /text\/event-stream/);
+    assert.doesNotMatch(body, /auth/i, "must not read as a credential problem");
+  } finally { stack.stop(); }
+});
+
+test("credential precedence and spelling are fixed, not incidental", async () => {
+  const stack = await startStack();
+  try {
+    // x-api-key wins when both are present. Either rule is defensible; an
+    // undefined one means two clients disagree about which key was used.
+    const both = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json", Accept: "application/json, text/event-stream",
+        "x-api-key": "FROM-HEADER", Authorization: "Bearer FROM-AUTH",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "search", arguments: { query: "q" } } }),
+    });
+    assert.equal(both.status, 200);
+    await both.text();
+    assert.deepEqual(stack.up.seenKeys, ["FROM-HEADER"]);
+
+    // Lowercase `bearer` is legal per RFC 7235 and some clients send it.
+    const lower = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", Authorization: "bearer plainkey" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    assert.equal(lower.status, 200, "a lowercase scheme must not be read as no credential");
+    await lower.text();
+
+    // Whitespace is not a credential — it must reach the challenge, not the
+    // upstream as a key made of spaces.
+    const blank = await probe(stack.srv.port, "tools/list", { "x-api-key": "   " });
+    assert.equal(blank.status, 401);
+    assert.deepEqual(stack.up.seenKeys, ["FROM-HEADER"], "a blank key must never be forwarded");
+  } finally { stack.stop(); }
+});
+
+test("non-POST methods and preflight answer without touching the MCP path", async () => {
+  const stack = await startStack();
+  try {
+    const get = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, { headers: { "x-api-key": "k" } });
+    assert.equal(get.status, 405, "stateless: there is no standalone SSE stream to GET");
+    assert.equal(get.headers.get("allow"), "POST, OPTIONS");
+    await get.text();
+
+    const opts = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp`, { method: "OPTIONS" });
+    assert.equal(opts.status, 204, "a failing preflight blocks every browser-based client");
+    assert.match(opts.headers.get("access-control-allow-headers") ?? "", /x-api-key/);
+  } finally { stack.stop(); }
+});
+
+test("the ?login entrypoint still works, for URLs already in circulation", async () => {
+  // It is no longer required, but anyone told to paste `…/mcp?login` earlier
+  // must not now get a different answer than the plain URL.
+  const stack = await startStack();
+  try {
+    const r = await probe(stack.srv.port, "initialize", {}, "?login");
+    assert.equal(r.status, 401);
+    assert.match(r.wwwAuth ?? "", /resource_metadata=/);
+  } finally { stack.stop(); }
+});
+
+test("a single-valued aud claim is accepted alongside the array form", async () => {
+  // fosite emits an array, but the spec permits a bare string and a future AS
+  // version could switch — silently rejecting every token would be the whole
+  // service down, so this is pinned.
+  const stack = await startStack();
+  try {
+    const r = await bearerCall(stack.srv.port, mint({ ...claims(stack.as), aud: RESOURCE }));
+    assert.equal(r.status, 200);
+  } finally { stack.stop(); }
+});
+
+test("a JWKS carrying no usable RSA key is a 503 that says so", async () => {
+  const stack = await startStack({ as: { jwks: "no-rsa" } });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    assert.equal(r.status, 503, "unusable key material is our problem, not the token's");
+    assertDiagnostic(r.msg.error.message, /no usable RSA keys/);
+  } finally { stack.stop(); }
+});
+
+// ---- The OAuth trigger clients actually act on --------------------------------
+//
+// Confirmed against pre before this was fixed: with no credential, initialize,
+// tools/list and tools/call all answered 200, and no response carried a
+// `WWW-Authenticate`. A client therefore concludes the server needs no
+// authorization, connects happily, lists tools, and only fails at the first
+// real call — with a message pointing at manual API-key setup. It never offers
+// to log in, because nothing ever told it there was anything to log into.
+
+/** POST one JSON-RPC method with optional headers; return status + headers. */
+async function probe(port, method, headers = {}, query = "") {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp${query}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", ...headers },
+    body: JSON.stringify({
+      jsonrpc: "2.0", id: 1, method,
+      params: method === "tools/call"
+        ? { name: "search", arguments: { query: "q" } }
+        : { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "probe", version: "1" } },
+    }),
+  });
+  const text = await res.text();
+  return { status: res.status, wwwAuth: res.headers.get("www-authenticate"), text };
+}
+
+test("every uncredentialed method answers 401 with the challenge, initialize included", async () => {
+  const stack = await startStack();
+  try {
+    for (const method of ["initialize", "tools/list", "tools/call"]) {
+      // Also without `?login`: gating the challenge on a query parameter made
+      // the whole flow depend on the user pasting `…/mcp?login` instead of the
+      // plain URL, which no client does on its own.
+      const r = await probe(stack.srv.port, method);
+      assert.equal(r.status, 401, `${method} answered ${r.status}; a client reads that as "no auth needed"`);
+      assert.match(r.wwwAuth ?? "", /^Bearer /, `${method} carried no challenge`);
+      assert.match(r.wwwAuth ?? "",
+        /resource_metadata="https:\/\/mcp\.octen\.example\/\.well-known\/oauth-protected-resource\/mcp"/);
+      // Verdicts must be readable from the status line: a rejection carries no
+      // `isError`, so a probe that greps for it reads a refusal as a success.
+      assert.doesNotMatch(r.text, /isError/, `${method} mixed a tool-level error into a transport rejection`);
+    }
+    await assertAlive(stack.srv, "uncredentialed probes");
+  } finally { stack.stop(); }
+});
+
+test("the advertised metadata URL resolves and names the authorization server", async () => {
+  const stack = await startStack();
+  try {
+    const { wwwAuth } = await probe(stack.srv.port, "initialize");
+    const url = wwwAuth.match(/resource_metadata="([^"]+)"/)[1];
+    // Follow the client's next step for real, against this server.
+    const doc = await fetch(`http://127.0.0.1:${stack.srv.port}${new URL(url).pathname}`);
+    assert.equal(doc.status, 200, "the challenge pointed at a document this server does not serve");
+    const prm = await doc.json();
+    assert.equal(prm.resource, RESOURCE);
+    assert.deepEqual(prm.authorization_servers, [stack.as.issuer]);
+    assert.ok(prm.scopes_supported.includes("mcp:tools"));
+  } finally { stack.stop(); }
+});
+
+test("a bare API key is never challenged — the two credential forms coexist", async () => {
+  const stack = await startStack();
+  try {
+    for (const headers of [{ "x-api-key": "plain-key" }, { Authorization: "Bearer plain-key" }]) {
+      const r = await probe(stack.srv.port, "initialize", headers);
+      assert.equal(r.status, 200, `challenged a request that carried a credential: ${JSON.stringify(headers)}`);
+      assert.equal(r.wwwAuth, null);
+    }
+    // And it reaches the upstream verbatim, not as something to be exchanged.
+    const call = await probe(stack.srv.port, "tools/call", { "x-api-key": "plain-key" });
+    assert.equal(call.status, 200);
+    assert.deepEqual(stack.up.seenKeys, ["plain-key"],
+      "a bare key must reach the upstream verbatim, not be exchanged for anything");
+  } finally { stack.stop(); }
+});
+
+test("a deployment with no authorization server advertises nothing and keeps call-time enforcement", async () => {
+  // Self-hosted, bare keys only: there is no AS to send anyone to, so a 401
+  // challenge would be a dead end. The pre-existing behaviour must survive.
+  const up = await startFaultyUpstream("ok");
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${up.port}` });
+  try {
+    const init = await probe(srv.port, "initialize");
+    assert.equal(init.status, 200, "an OAuth-less deployment must still allow anonymous discovery");
+    assert.equal(init.wwwAuth, null, "nothing may be advertised when there is no authorization server");
+
+    const list = await probe(srv.port, "tools/list");
+    assert.equal(list.status, 200);
+
+    const call = await probe(srv.port, "tools/call");
+    assert.equal(call.status, 200, "without an AS, a missing key stays a tool-level result");
+    assert.match(call.text, /isError/);
+    assert.match(call.text, /x-api-key/);
+
+    assert.equal((await fetch(`http://127.0.0.1:${srv.port}/.well-known/oauth-protected-resource`)).status, 404);
+  } finally { srv.stop(); up.close(); }
+});
+
+test("the revocation window is configurable, and zero means resolve every time", async () => {
+  // Measured on pre: a grant revoked at t=0 still worked at t=45s. That is the
+  // cache TTL, and it is a trade worth being able to see and set rather than
+  // discovering it from a stopwatch.
+  const stack = await startStack({ env: { OCTEN_OAUTH_RESOLVE_CACHE_TTL_MS: "0" } });
+  try {
+    await bearerCall(stack.srv.port, mint(claims(stack.as)), { id: 2 });
+    await bearerCall(stack.srv.port, mint(claims(stack.as)), { id: 3 });
+    assert.equal(stack.as.hits.resolve, 2,
+      "TTL 0 must consult the authorization server on every call");
+  } finally { stack.stop(); }
+});
+
+// ---- The OAuth path must use the same tuned HTTP stack ------------------------
+
+/**
+ * Recording proxy. undici tunnels with CONNECT even for plain `http://`
+ * origins, so this is a tunnel rather than a forwarder — and because the
+ * tunnelled bytes are unencrypted HTTP, the request line inside can be read,
+ * which is what makes the assertion specific about *which* endpoint went
+ * through the proxy rather than merely that something did.
+ */
+function startProxy() {
+  const seen = [];
+  const sockets = new Set();
+  const srv = http.createServer((_req, res) => { res.writeHead(405); res.end(); });
+  srv.on("connect", (req, clientSocket, head) => {
+    const [host, port] = req.url.split(":");
+    const upstream = net.connect(Number(port), host, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head?.length) upstream.write(head);
+      clientSocket.on("data", (chunk) => {
+        const m = chunk.toString("latin1").match(/^[A-Z]+ (\S+) HTTP\/1\.[01]/);
+        if (m) seen.push(m[1]);
+      });
+      clientSocket.pipe(upstream);
+      upstream.pipe(clientSocket);
+    });
+    sockets.add(clientSocket).add(upstream);
+    upstream.on("error", () => clientSocket.destroy());
+    clientSocket.on("error", () => upstream.destroy());
+  });
+  return new Promise((r) => srv.listen(0, () => r({
+    port: srv.address().port, seen,
+    close: () => { for (const s of sockets) s.destroy(); srv.close(); },
+  })));
+}
+
+test("JWKS and resolve-key go through the configured proxy, like every other call", async () => {
+  // The defect this pins: these two calls used undici's *global* dispatcher
+  // rather than the module's configured one, so they ignored the proxy
+  // environment entirely. Behind a corporate proxy that means OAuth cannot
+  // work while every other request can — and nothing in the error would say
+  // so. It is the same class of bug 0.4.0 fixed for the API calls, in the code
+  // added after it.
+  const proxy = await startProxy();
+  const as = await startAs();
+  const up = await startFaultyUpstream("ok");
+  const srv = await startHttp({
+    OCTEN_API_URL: `http://127.0.0.1:${up.port}`,
+    OCTEN_OAUTH_AUTHORIZATION_SERVER: as.issuer,
+    OCTEN_MCP_RESOURCE: RESOURCE,
+    OCTEN_OAUTH_RESOLVE_URL: `${as.issuer}/internal/oauth/resolve-key`,
+    OCTEN_OAUTH_RESOLVE_TOKEN: "svc-secret",
+    HTTP_PROXY: `http://127.0.0.1:${proxy.port}`,
+    http_proxy: `http://127.0.0.1:${proxy.port}`,
+  });
+  try {
+    const r = await bearerCall(srv.port, mint(claims(as)));
+    assert.equal(r.status, 200, `call failed through the proxy: ${JSON.stringify(r.msg)}`);
+    assert.ok(proxy.seen.some((u) => u.includes("/api/oauth/jwks")),
+      `JWKS bypassed the proxy; the proxy only saw: ${JSON.stringify(proxy.seen)}`);
+    assert.ok(proxy.seen.some((u) => u.includes("/internal/oauth/resolve-key")),
+      `resolve-key bypassed the proxy; the proxy only saw: ${JSON.stringify(proxy.seen)}`);
+  } finally { srv.stop(); up.close(); as.close(); proxy.close(); }
+});
+
+// ---- Every failure must name its cause ---------------------------------------
+//
+// A generic message is not a cosmetic problem. The 0.3.7 field report that
+// started this whole line of work consisted of `fetch failed` repeated: the
+// user could not tell a proxy from a DNS failure, and neither could we, so the
+// exchange went several rounds before anyone learned anything. Every branch
+// below used to answer with a sentence that fit any of a dozen causes.
+
+/** Phrases that describe nothing. A message consisting only of these is a bug. */
+const VAGUE = [
+  /^Authorization backend temporarily unavailable/,
+  /^Invalid or expired access token; re-authorize\.$/,
+  /^Internal server error$/,
+  /^Authentication required\.$/,
+  /^not found$/,
+  /fetch failed/,
+  /code=UNKNOWN/,
+];
+
+function assertDiagnostic(message, mustMention) {
+  for (const v of VAGUE) {
+    assert.doesNotMatch(message, v, `message says nothing actionable: ${JSON.stringify(message)}`);
+  }
+  assert.match(message, mustMention, `message does not name the cause: ${JSON.stringify(message)}`);
+}
+
+test("an unreachable authorization server names the dependency and the transport code", async () => {
+  // A port nothing listens on, so the failure is a real ECONNREFUSED rather
+  // than a URL-validation error.
+  const dead = await new Promise((r) => {
+    const s = http.createServer(); s.listen(0, () => { const p = s.address().port; s.close(() => r(p)); });
+  });
+  const stack = await startStack({ env: { OCTEN_OAUTH_AUTHORIZATION_SERVER: `http://127.0.0.1:${dead}` } });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as, { iss: `http://127.0.0.1:${dead}` })));
+    assert.equal(r.status, 503);
+    assertDiagnostic(r.msg.error.message, /JWKS/);
+    assert.match(r.msg.error.message, /ECONNREFUSED|ECONNRESET|EHOSTUNREACH/,
+      "the undici cause code is the part that distinguishes refused from filtered from unresolvable");
+    // And it must say which way to fall: retry, not re-authorize.
+    assert.match(r.msg.error.message, /retry/i);
+  } finally { stack.stop(); }
+});
+
+test("each token rejection reason survives into the response body, not just the log", async () => {
+  const stack = await startStack();
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const cases = [
+      // [claims, what the message must let the reader act on]
+      [{ ...claims(stack.as), exp: now - 4000 }, /expired \d+s ago/],
+      [{ ...claims(stack.as), aud: ["https://mcp.octen.example/mcp/"] }, /audience .*mcp\.octen\.example\/mcp\//],
+      [{ ...claims(stack.as), iss: "https://evil.example" }, /issued by https:\/\/evil\.example/],
+      [{ ...claims(stack.as), scp: ["other:scope"] }, /mcp:tools scope/],
+      [{ ...claims(stack.as), grant_id: undefined }, /no grant_id/],
+      [{ ...claims(stack.as), kid: "rotated-away" }, /kid=rotated-away/],
+    ];
+    for (const [c, expected] of cases) {
+      const r = await bearerCall(stack.srv.port, mint(c));
+      assert.equal(r.status, 401);
+      assertDiagnostic(r.msg.error.message, expected);
+      // The challenge carries it too, sanitised — that is what a client logs.
+      assert.match(r.wwwAuth, /error_description="[^"]{20,}"/,
+        `challenge lost the reason: ${r.wwwAuth}`);
+    }
+    await assertAlive(stack.srv, "token rejection reasons");
+  } finally { stack.stop(); }
+});
+
+test("the audience mismatch message shows both values, because the difference is one character", async () => {
+  const stack = await startStack();
+  try {
+    const r = await bearerCall(stack.srv.port, mint({ ...claims(stack.as), aud: [RESOURCE + "/"] }));
+    // RFC 8707 binds byte-for-byte, so a trailing slash fails everything —
+    // and is unfindable unless the two strings are printed next to each other.
+    assert.match(r.msg.error.message, new RegExp(`${RESOURCE.replace(/[/.]/g, "\\$&")}/`));
+    assert.match(r.msg.error.message, new RegExp(`this resource is ${RESOURCE.replace(/[/.]/g, "\\$&")}`));
+  } finally { stack.stop(); }
+});
+
+test("a resolve-key auth failure blames this server's token, not the caller's", async () => {
+  const stack = await startStack({ env: { OCTEN_OAUTH_RESOLVE_TOKEN: "wrong-service-token" } });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    assert.equal(r.status, 503, "our own misconfiguration must not be reported as the user's token being bad");
+    assertDiagnostic(r.msg.error.message, /service token/);
+    // The distinction under test is who is at fault. Saying "your token is
+    // invalid" here sends the user round a re-authorization loop that cannot
+    // fix a secret only we can rotate; the message must point at us instead.
+    assert.doesNotMatch(r.msg.error.message, /(your|the) (access )?token (is|was) (invalid|expired|rejected)/i,
+      `blames the caller for a server-side secret: ${r.msg.error.message}`);
+    assert.match(r.msg.error.message, /rather than re-authorizing/,
+      "must steer the client to retry, since re-authorizing cannot help");
+  } finally { stack.stop(); }
+});
+
+test("a resolve endpoint answering 500 names the dependency and the status", async () => {
+  const stack = await startStack({ as: { resolve: "http500" } });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    assert.equal(r.status, 503);
+    assertDiagnostic(r.msg.error.message, /grant-resolution service answered HTTP 500/);
+  } finally { stack.stop(); }
+});
+
+test("error messages never leak the internal resolve address", async () => {
+  const stack = await startStack({ as: { resolve: "http500" } });
+  try {
+    const r = await bearerCall(stack.srv.port, mint(claims(stack.as)));
+    // Specific about the fault, silent about internal topology — the resolve
+    // endpoint is a cluster-internal address and this body goes to the public
+    // internet.
+    assert.doesNotMatch(r.msg.error.message, /internal\/oauth|127\.0\.0\.1|svc\.cluster\.local/,
+      `internal address leaked: ${r.msg.error.message}`);
+  } finally { stack.stop(); }
+});
+
+test("a missing credential says which headers are accepted", async () => {
+  const stack = await startStack();
+  try {
+    const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp?login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    });
+    const body = await res.json();
+    assertDiagnostic(body.error.message, /x-api-key/);
+    assert.match(body.error.message, /Authorization: Bearer/);
+  } finally { stack.stop(); }
+});
+
+// ---- Resource-metadata path derivation --------------------------------------
+
+test("the advertised metadata URL is derived from the resource path, and is served there", async () => {
+  const stack = await startStack({ env: { OCTEN_MCP_RESOURCE: "https://host.example/deep/path/mcp" } });
+  try {
+    const res = await fetch(`http://127.0.0.1:${stack.srv.port}/mcp?login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+    });
+    assert.equal(res.status, 401);
+    const advertised = res.headers.get("www-authenticate").match(/resource_metadata="([^"]+)"/)[1];
+    assert.equal(advertised, "https://host.example/.well-known/oauth-protected-resource/deep/path/mcp",
+      "a hardcoded /mcp would advertise a document this deployment does not serve");
+    // The advertised path must actually resolve here, or clients following the
+    // challenge land on a 404 with no way forward.
+    const doc = await fetch(`http://127.0.0.1:${stack.srv.port}${new URL(advertised).pathname}`);
+    assert.equal(doc.status, 200);
+    assert.equal((await doc.json()).resource, "https://host.example/deep/path/mcp");
+    await assertAlive(stack.srv, "path-derived metadata");
+  } finally { stack.stop(); }
+});

--- a/test/apiContract.test.mjs
+++ b/test/apiContract.test.mjs
@@ -1,0 +1,187 @@
+/**
+ * The declared limits must match the published API reference.
+ *
+ * This matters more since the schemas became a gate rather than advertising:
+ * a limit stricter than the API's now *rejects calls the API would serve*, and
+ * one looser lets a request through to fail upstream with a worse message.
+ * Both were live — `exclude_domains` was declared at 150 against a documented
+ * 1200, and every domain longer than 30 characters was refused against a
+ * documented 60. Nothing failed, because nothing compared the two.
+ *
+ * The table below is transcribed from docs.octen.ai/api-reference/*. When the
+ * API changes, this test is the thing that should fail — update the table, not
+ * the schema, and the mismatch will point at what else needs to move.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.OCTEN_API_KEY = process.env.OCTEN_API_KEY ?? "test-key";
+
+const { searchTool, newsSearchTool, broadSearchTool } = await import("../dist/search.js");
+const { extractTool } = await import("../dist/extract.js");
+const { imageSearchTool } = await import("../dist/imageSearch.js");
+const { videoSearchTool } = await import("../dist/videoSearch.js");
+
+/** docs.octen.ai/api-reference — verified 2026-08-31. */
+const DOCUMENTED = {
+  search: {
+    tool: searchTool,
+    fields: {
+      "query": { maxLength: 500 },
+      "count": { minimum: 1, maximum: 100 },
+      "include_domains": { maxItems: 1200, itemMaxLength: 60 },
+      "exclude_domains": { maxItems: 1200, itemMaxLength: 60 },
+      "include_text": { maxItems: 5, itemMaxLength: 30 },
+      "exclude_text": { maxItems: 5, itemMaxLength: 30 },
+      "highlight.max_tokens": { minimum: 100, maximum: 20000 },
+      "full_content.max_tokens": { minimum: 100, maximum: 100000 },
+    },
+  },
+  // Same engine, so the same options table applies — and it is derived from
+  // searchTool's, which is exactly why a drift there would go unnoticed here.
+  news_search: {
+    tool: newsSearchTool,
+    fields: {
+      "count": { minimum: 1, maximum: 100 },
+      "include_domains": { maxItems: 1200, itemMaxLength: 60 },
+    },
+  },
+  broad_search: {
+    tool: broadSearchTool,
+    fields: {
+      "query": { maxLength: 500 },
+      "max_queries": { minimum: 1, maximum: 30 },
+      "count": { minimum: 1, maximum: 100 },
+      "include_domains": { maxItems: 1200, itemMaxLength: 60 },
+      "exclude_domains": { maxItems: 1200, itemMaxLength: 60 },
+    },
+  },
+  extract: {
+    tool: extractTool,
+    fields: {
+      "urls": { maxItems: 20, itemMaxLength: 2048 },
+      "query": { maxLength: 500 },
+      "timeout": { minimum: 1, maximum: 60 },
+      "max_age_seconds": { minimum: 300, maximum: 31536000 },
+    },
+  },
+  image_search: {
+    tool: imageSearchTool,
+    fields: {
+      "count": { minimum: 1, maximum: 10 },
+      "html_snippet.max_tokens": { minimum: 100, maximum: 100000 },
+    },
+  },
+  video_search: {
+    tool: videoSearchTool,
+    fields: { "count": { minimum: 1, maximum: 10 } },
+  },
+};
+
+const at = (schema, path) =>
+  path.split(".").reduce((s, k) => s?.properties?.[k], schema);
+
+for (const [name, { tool, fields }] of Object.entries(DOCUMENTED)) {
+  test(`${name}'s declared limits match the published API reference`, () => {
+    for (const [field, want] of Object.entries(fields)) {
+      const s = at(tool.inputSchema, field);
+      assert.ok(s, `${name} does not declare \`${field}\`, which the API documents`);
+      const got = {
+        minimum: s.minimum, maximum: s.maximum, maxLength: s.maxLength,
+        maxItems: s.maxItems, itemMaxLength: s.items?.maxLength,
+      };
+      for (const [k, v] of Object.entries(want)) {
+        assert.equal(got[k], v,
+          `${name}.${field}.${k} is ${got[k]}, the API documents ${v} — ` +
+          `too strict rejects valid calls, too loose defers the error upstream`);
+      }
+    }
+  });
+}
+
+test("enum values match the published API reference", () => {
+  const enums = [
+    [searchTool, "topic", ["general", "news"]],
+    [searchTool, "time_basis", ["auto", "published", "crawled"]],
+    [searchTool, "time_range", ["day", "week", "month", "year", "d", "w", "m", "y"]],
+    [searchTool, "format", ["text", "markdown"]],
+    [searchTool, "safesearch", ["off", "strict"]],
+    [extractTool, "format", ["markdown", "text"]],
+    [imageSearchTool, "safesearch", ["off", "strict"]],
+    [videoSearchTool, "safesearch", ["off", "strict"]],
+  ];
+  for (const [tool, field, want] of enums) {
+    const s = at(tool.inputSchema, field);
+    assert.ok(s, `${tool.name} does not declare \`${field}\``);
+    assert.deepEqual([...s.enum].sort(), [...want].sort(),
+      `${tool.name}.${field} enum drifted from the API reference`);
+  }
+});
+
+/**
+ * `timeout` is ours, not the API's: it is the client-side HTTP deadline and is
+ * stripped from every request body before sending. It is the only name allowed
+ * to appear in a schema without appearing in the API reference.
+ */
+const CLIENT_ONLY = new Set(["timeout"]);
+
+/** Parameter names each endpoint's reference documents, after our flattening. */
+const DOCUMENTED_PARAMS = {
+  // `inputs[]` is flattened into `query` / `image_url`; `search_options` is
+  // flattened to the top level. Those are presentation choices — the request
+  // bodies we build are asserted against the documented shapes elsewhere.
+  // `inputs[]` flattens to three: `query` is `inputs.data` for a text input,
+  // `image_url` is `inputs.url`, `image_data` is `inputs.data` for an image.
+  image_search: ["query", "image_url", "image_data", "topic", "count",
+                 "include_domains", "exclude_domains", "safesearch", "html_snippet"],
+  video_search: ["query", "count", "time_range", "start_time", "end_time", "safesearch"],
+  extract: ["urls", "query", "max_age_seconds", "format", "timeout",
+            "include_images", "include_videos", "include_audio"],
+};
+
+test("no tool advertises a parameter the API reference does not document", () => {
+  const byName = { image_search: imageSearchTool, video_search: videoSearchTool, extract: extractTool };
+  for (const [name, documented] of Object.entries(DOCUMENTED_PARAMS)) {
+    const declared = Object.keys(byName[name].inputSchema.properties);
+    const extra = declared.filter((p) => !documented.includes(p) && !CLIENT_ONLY.has(p));
+    assert.deepEqual(extra, [],
+      `${name} advertises ${extra.join(", ")}, which its API reference does not document`);
+  }
+  // And the other direction: a documented parameter we do not offer is a
+  // capability the caller simply cannot reach.
+  for (const [name, documented] of Object.entries(DOCUMENTED_PARAMS)) {
+    const declared = Object.keys(byName[name].inputSchema.properties);
+    const missing = documented.filter((p) => !declared.includes(p));
+    assert.deepEqual(missing, [], `${name} does not offer documented ${missing.join(", ")}`);
+  }
+});
+
+test("time filtering is offered where documented and nowhere else", () => {
+  // video-search documents time_range / start_time / end_time; image-search
+  // does not. They were declared on both, and image_search really did send
+  // them — the API accepted them, but a parameter we advertise and the API
+  // does not document is one nobody has committed to keeping.
+  for (const f of ["time_range", "start_time", "end_time"]) {
+    assert.ok(f in videoSearchTool.inputSchema.properties, `video_search must keep ${f}`);
+    assert.ok(!(f in imageSearchTool.inputSchema.properties),
+      `image_search must not advertise ${f}: its API reference does not document it`);
+  }
+});
+
+test("legacy: no tool advertises include_videos outside extract", () => {
+  // `include_videos` was declared on search and does not appear in that
+  // endpoint's parameter table. It did have an effect when sent — but a
+  // parameter we advertise and the API does not document is one we cannot
+  // promise, and the schemas are a gate now, not a suggestion.
+  assert.ok(!("include_videos" in searchTool.inputSchema.properties),
+    "search must not advertise include_videos: the API reference does not document it");
+  assert.ok(!("include_videos" in broadSearchTool.inputSchema.properties),
+    "broad_search derives its options from search — it inherits the same rule");
+  assert.ok(!("include_videos" in newsSearchTool.inputSchema.properties));
+
+  // extract's three media flags *are* documented, and must stay.
+  for (const f of ["include_images", "include_videos", "include_audio"]) {
+    assert.ok(f in extractTool.inputSchema.properties,
+      `extract documents ${f} — removing it would be the opposite error`);
+  }
+});

--- a/test/bodyTimeout.test.mjs
+++ b/test/bodyTimeout.test.mjs
@@ -61,7 +61,7 @@ function callViaStdio(env, args, { killAfterMs = 12000 } = {}) {
   });
 }
 
-test("a response whose body stalls mid-stream is reported as a timeout, not as malformed JSON", async () => {
+test("[stdio transport] a stalled response body is reported as a timeout, not as malformed JSON", async () => {
   const upstream = http.createServer((_req, res) => {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.write('{"code":0,"data":{"resul'); // half a body, then silence
@@ -155,7 +155,7 @@ test("infrastructure response headers never leak into user-facing error text", a
   } finally { upstream.close(); }
 });
 
-test("an upstream that accepts and never answers hits the tool deadline at real elapsed time", async () => {
+test("[stdio transport] an upstream that accepts and never answers hits the tool deadline at real elapsed time", async () => {
   // The in-process suite fakes TimeoutError objects; this one earns it: the
   // socket connects fine and then nothing ever comes back.
   const upstream = http.createServer(() => { /* accept, read, say nothing */ });

--- a/test/docs.test.mjs
+++ b/test/docs.test.mjs
@@ -1,0 +1,57 @@
+/**
+ * Documentation that goes stale is worse than absent: a reader who finds a
+ * variable table trusts it to be the whole list.
+ *
+ * This started as a real gap — the HTTP transport and the OAuth work between
+ * them added eleven environment variables, and none of the eleven reached the
+ * README. Nothing failed, so nobody noticed. The check below is the cheapest
+ * thing that would have.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Every environment variable name `src/` reads. */
+function envNamesInSource() {
+  const found = new Set();
+  for (const f of readdirSync(path.join(root, "src")).filter((f) => f.endsWith(".ts"))) {
+    const src = readFileSync(path.join(root, "src", f), "utf8");
+    // `process.env.NAME`, `process.env["NAME"]`, and the envInt/envFlag helpers.
+    for (const re of [
+      /process\.env\.([A-Z][A-Z0-9_]+)/g,
+      /process\.env\[["']([A-Z][A-Z0-9_]+)["']\]/g,
+      /env(?:Int|Flag|FlagDefaultOn)\(\s*["']([A-Z][A-Z0-9_]+)["']/g,
+    ]) {
+      for (const m of src.matchAll(re)) found.add(m[1]);
+    }
+  }
+  return found;
+}
+
+test("every environment variable the code reads is documented in the README", () => {
+  const readme = readFileSync(path.join(root, "README.md"), "utf8");
+  const undocumented = [...envNamesInSource()]
+    .filter((n) => !readme.includes(`\`${n}\``))
+    .sort();
+  assert.deepEqual(undocumented, [],
+    "these are read by src/ but absent from the README's variable tables");
+});
+
+test("the documented hosted endpoint is the one this server actually advertises", () => {
+  // Replaces an earlier test that forbade naming the endpoint at all, back
+  // when it did not resolve. Now that it does, the risk inverts: a README that
+  // names a *different* URL than the deployment's `OCTEN_MCP_RESOURCE` sends
+  // clients to fetch protected-resource metadata that will not match their
+  // token's audience, and RFC 8707 compares that byte-for-byte.
+  const readme = readFileSync(path.join(root, "README.md"), "utf8");
+  assert.match(readme, /https:\/\/mcp\.octen\.ai\/mcp/, "the hosted endpoint should be documented");
+  const urls = [...readme.matchAll(/https:\/\/mcp\.octen\.ai[^\s`"')\]]*/g)].map((m) => m[0]);
+  for (const u of urls) {
+    assert.match(u, /^https:\/\/mcp\.octen\.ai(\/mcp(\/oauth)?(\?[^\s]*)?|\/\.well-known\/[^\s]*)?$/,
+      `${u} is not a path this server serves — /mcp, /mcp/oauth and the well-knowns are`);
+  }
+});

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -1,0 +1,101 @@
+/**
+ * Shared harness for tests that drive the built HTTP entry as a real process
+ * against real sockets. Not matched by the test glob (no `.test.` infix).
+ */
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+export const SERVER = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "dist", "httpServer.js");
+
+/** Start the HTTP server on an ephemeral port; resolve { port, stop, stderr() }. */
+export function startHttp(env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [SERVER], {
+      env: {
+        ...process.env, PORT: "0",
+        HTTPS_PROXY: "", https_proxy: "", HTTP_PROXY: "", http_proxy: "",
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let err = "";
+    const exited = new Promise((r) => child.on("exit", (code) => r(code)));
+    const timer = setTimeout(() => reject(new Error(`server did not start:\n${err}`)), 8000);
+    child.stderr.on("data", (d) => {
+      err += d;
+      const m = err.match(/listening on :(\d+)\/mcp/);
+      if (m) {
+        clearTimeout(timer);
+        resolve({ port: Number(m[1]), child, exited, stop: () => child.kill(), stderr: () => err });
+      }
+    });
+  });
+}
+
+/**
+ * Wait for a pattern to appear in a server's stderr, bounded.
+ *
+ * Some events are written after the client's socket is already gone — a drain
+ * finishes once the peer stops sending, which is strictly later than the
+ * response the test was waiting on. Sampling `stderr()` once at that moment
+ * asks the server to have already logged something it has no reason to have
+ * logged yet. That passes on a fast machine and fails on a loaded CI runner,
+ * which is how this arrived: green locally, red on all five Node versions.
+ *
+ * Returns the accumulated stderr either way, so the caller's assertion still
+ * produces the full log on failure rather than a bare timeout.
+ */
+export async function waitForStderr(srv, re, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (re.test(srv.stderr())) return srv.stderr();
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return srv.stderr();
+}
+
+/** Stub upstream API that records the x-api-key of every request it receives. */
+export function startUpstream() {
+  const seenKeys = [];
+  const srv = http.createServer((req, res) => {
+    seenKeys.push(req.headers["x-api-key"]);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      code: 0,
+      data: { results: [{ title: `echo:${req.headers["x-api-key"]}`, url: "http://x" }] },
+      meta: {},
+    }));
+  });
+  return new Promise((resolve) => srv.listen(0, () =>
+    resolve({ port: srv.address().port, seenKeys, close: () => srv.close() })));
+}
+
+/** POST one JSON-RPC message; parse the SSE or JSON response into the message. */
+export async function rpc(port, body, headers = {}) {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if ((res.headers.get("content-type") ?? "").includes("text/event-stream")) {
+    const data = text.split("\n").filter((l) => l.startsWith("data: ")).pop();
+    return { status: res.status, msg: data ? JSON.parse(data.slice(6)) : undefined, raw: text };
+  }
+  return { status: res.status, msg: text ? JSON.parse(text) : undefined, raw: text };
+}
+
+export const INIT = {
+  jsonrpc: "2.0", id: 1, method: "initialize",
+  params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "t", version: "1" } },
+};
+export const call = (id, query) => ({
+  jsonrpc: "2.0", id, method: "tools/call",
+  params: { name: "search", arguments: { query } },
+});

--- a/test/http.test.mjs
+++ b/test/http.test.mjs
@@ -277,17 +277,21 @@ test("every tool relays a server envelope error verbatim with the server's reque
 test("every tool rejects empty input before touching the network", async () => {
   let fetched = false;
   _setFetchForTests(async () => { fetched = true; throw new Error("must not be called"); });
+  // Each tool states its own rule, so each gets its own expected wording — a
+  // shared pattern would have to be so loose it stopped checking anything.
+  // `image_search` takes exactly one of two inputs rather than one required
+  // one, so "must be a non-empty query" is not what it should say.
   const EMPTY = [
-    () => handleSearch({ query: "  " }),
-    () => handleBroadSearch({ query: "" }),
-    () => handleExtract({ urls: [] }),
-    () => handleImageSearch({ query: "  " }),
-    () => handleVideoSearch({ query: "" }),
+    [() => handleSearch({ query: "  " }), /must be a non-empty/],
+    [() => handleBroadSearch({ query: "" }), /must be a non-empty/],
+    [() => handleExtract({ urls: [] }), /must be a non-empty/],
+    [() => handleImageSearch({}), /`query`.*`image_url`|`image_url`.*`query`/],
+    [() => handleVideoSearch({ query: "" }), /must be a non-empty/],
   ];
-  for (const invoke of EMPTY) {
+  for (const [invoke, expected] of EMPTY) {
     const out = await invoke();
     assert.equal(out.isError, true);
-    assert.match(textOf(out), /must be a non-empty/);
+    assert.match(textOf(out), expected);
   }
   assert.equal(fetched, false, "validation failures must not reach the network");
 });

--- a/test/httpServer.test.mjs
+++ b/test/httpServer.test.mjs
@@ -1,0 +1,376 @@
+/**
+ * Tests for the remote HTTP entry (built output).
+ *
+ * The design under test:
+ * stateless Streamable HTTP, `initialize`/`tools/list` unauthenticated, auth
+ * enforced at `tools/call`, and both `x-api-key` and `Authorization: Bearer`
+ * accepted. The most important case here is key isolation — one process serves
+ * many tenants, and nothing in the in-process suites exercises that.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { startHttp, startUpstream, rpc, call, INIT } from "./helpers.mjs";
+
+test("healthz answers without touching the upstream", async () => {
+  const srv = await startHttp();
+  try {
+    const res = await fetch(`http://127.0.0.1:${srv.port}/healthz`);
+    const body = await res.json();
+    assert.equal(res.status, 200);
+    assert.equal(body.name, "octen-mcp");
+    assert.match(body.version, /^\d+\.\d+\.\d+$/);
+  } finally { srv.stop(); }
+});
+
+test("initialize succeeds without a credential (auth is enforced at call time)", async () => {
+  const srv = await startHttp();
+  try {
+    const { status, msg } = await rpc(srv.port, INIT);
+    assert.equal(status, 200);
+    assert.equal(msg.result.serverInfo.name, "octen-mcp");
+  } finally { srv.stop(); }
+});
+
+test("tools/list succeeds without a credential and shows all six tools", async () => {
+  const srv = await startHttp();
+  try {
+    const { msg } = await rpc(srv.port, { jsonrpc: "2.0", id: 2, method: "tools/list" });
+    assert.deepEqual(
+      msg.result.tools.map((t) => t.name).sort(),
+      ["broad_search", "extract", "image_search", "news_search", "search", "video_search"]
+    );
+  } finally { srv.stop(); }
+});
+
+test("tools/call without a credential fails with header guidance, not an env-var hint", async () => {
+  const srv = await startHttp();
+  try {
+    const { msg } = await rpc(srv.port, call(3, "x"));
+    assert.equal(msg.result.isError, true);
+    const text = msg.result.content[0].text;
+    assert.match(text, /x-api-key/, "the fix for an HTTP caller is a header, and the error must say so");
+    assert.match(text, /Bearer/);
+    assert.doesNotMatch(text, /env var/, "env-var advice is wrong for a remote caller");
+  } finally { srv.stop(); }
+});
+
+test("x-api-key header reaches the upstream", async () => {
+  const up = await startUpstream();
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${up.port}` });
+  try {
+    const { msg } = await rpc(srv.port, call(4, "x"), { "x-api-key": "key-alpha" });
+    assert.notEqual(msg.result.isError, true, msg.result.content?.[0]?.text);
+    assert.deepEqual(up.seenKeys, ["key-alpha"]);
+  } finally { srv.stop(); up.close(); }
+});
+
+test("Authorization: Bearer is accepted as the same credential (Codex-style clients)", async () => {
+  const up = await startUpstream();
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${up.port}` });
+  try {
+    const { msg } = await rpc(srv.port, call(5, "x"), { Authorization: "Bearer key-bravo" });
+    assert.notEqual(msg.result.isError, true, msg.result.content?.[0]?.text);
+    assert.deepEqual(up.seenKeys, ["key-bravo"]);
+  } finally { srv.stop(); up.close(); }
+});
+
+test("concurrent requests with different keys never receive each other's credential", async () => {
+  // The whole multi-tenant premise. If the key ever lands in module state
+  // instead of per-request closure, concurrent tenants swap credentials —
+  // quota billed to the wrong account at best, data under the wrong account
+  // at worst — and every single-caller test stays green while it happens.
+  const up = await startUpstream();
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${up.port}` });
+  try {
+    const keys = ["tenant-a", "tenant-b", "tenant-c", "tenant-d"];
+    const results = await Promise.all(keys.map((k, i) =>
+      rpc(srv.port, call(10 + i, `q-${k}`), { "x-api-key": k })));
+    for (const [i, r] of results.entries()) {
+      assert.notEqual(r.msg.result.isError, true);
+      // The stub echoes the key it saw into the result title.
+      assert.match(
+        r.msg.result.content[0].text, new RegExp(`echo:${keys[i]}`),
+        `request sent with ${keys[i]} was served with someone else's credential`
+      );
+    }
+    assert.deepEqual([...up.seenKeys].sort(), [...keys].sort());
+  } finally { srv.stop(); up.close(); }
+});
+
+test("the environment's key is never used as a fallback for HTTP callers", async () => {
+  // stdio's env fallback must not leak here: a request with no key must fail,
+  // not silently ride the deployment's own credential.
+  const up = await startUpstream();
+  const srv = await startHttp({
+    OCTEN_API_URL: `http://127.0.0.1:${up.port}`,
+    OCTEN_API_KEY: "deployment-secret",
+  });
+  try {
+    const { msg } = await rpc(srv.port, call(6, "x"));
+    assert.equal(msg.result.isError, true, "keyless request must fail even when the process env has a key");
+    assert.equal(up.seenKeys.length, 0, "the deployment's own key leaked to an unauthenticated caller");
+  } finally { srv.stop(); up.close(); }
+});
+
+test("GET /mcp is 405 (stateless: no standalone SSE stream)", async () => {
+  const srv = await startHttp();
+  try {
+    const res = await fetch(`http://127.0.0.1:${srv.port}/mcp`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    assert.equal(res.status, 405);
+  } finally { srv.stop(); }
+});
+
+test("a request whose body arrives late keeps its own key (deterministic isolation)", async () => {
+  // The concurrent test above guards the observable contract, but the race
+  // window for shared-key-state bugs sits between a request's HEADERS arriving
+  // and its dispatch — i.e. during the body-read await. Promise.all cannot
+  // reliably land inside it. This constructs the interleaving exactly:
+  //
+  //   A: headers + half the body (key tenant-A) ... stall ...
+  //   B: complete request (key tenant-B)          ← would overwrite shared state
+  //   A: rest of the body                         ← A dispatches; must still be tenant-A
+  const net = await import("node:net");
+  const up = await startUpstream();
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${up.port}` });
+  try {
+    const bodyA = JSON.stringify(call(20, "slow-body"));
+    const half = Math.floor(bodyA.length / 2);
+
+    const sock = net.connect(srv.port, "127.0.0.1");
+    await new Promise((r) => sock.on("connect", r));
+    sock.write(
+      `POST /mcp HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\n` +
+      `Accept: application/json, text/event-stream\r\nx-api-key: tenant-A\r\n` +
+      `Content-Length: ${bodyA.length}\r\n\r\n` + bodyA.slice(0, half)
+    );
+    // Let A's headers be fully processed before B goes through.
+    await new Promise((r) => setTimeout(r, 150));
+
+    const b = await rpc(srv.port, call(21, "fast"), { "x-api-key": "tenant-B" });
+    assert.notEqual(b.msg.result.isError, true);
+
+    // Now complete A and read its response.
+    let respA = "";
+    sock.on("data", (d) => (respA += d));
+    sock.write(bodyA.slice(half));
+    await new Promise((r) => setTimeout(r, 800));
+    sock.destroy();
+
+    assert.match(
+      respA, /echo:tenant-A/,
+      `request A was served with a credential overwritten during its body read:\n${respA.slice(-300)}`
+    );
+    assert.deepEqual([...up.seenKeys].sort(), ["tenant-A", "tenant-B"]);
+  } finally { srv.stop(); up.close(); }
+});
+
+test("oversized bodies are refused with 413 before parsing", async () => {
+  // The cap is set explicitly rather than inherited: what is under test is
+  // "over the cap is 413", not what the cap happens to default to. Pinning it
+  // to the default meant this test had to be rewritten the day the default
+  // moved to make room for base64 images.
+  const srv = await startHttp({ OCTEN_MCP_MAX_BODY: "65536" });
+  try {
+    const res = await fetch(`http://127.0.0.1:${srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call",
+        params: { name: "search", arguments: { query: "x".repeat(65536 + 100) } } }),
+    });
+    assert.equal(res.status, 413);
+    await res.text();
+  } finally { srv.stop(); }
+});
+
+test("OCTEN_MCP_LOG=json emits parseable structured events and never the full key", async () => {
+  const up = await startUpstream();
+  const secret = "secret-key-abcdef123456";
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${up.port}`, OCTEN_MCP_LOG: "json" });
+  try {
+    await rpc(srv.port, call(30, "x"), { "x-api-key": secret });
+    // Give the trailing call_returning line a beat to flush.
+    await new Promise((r) => setTimeout(r, 200));
+    const err = srv.stderr();
+
+    // Redaction is the non-negotiable property of this log mode.
+    assert.doesNotMatch(err, new RegExp(secret), "the full API key leaked into logs");
+    // Fingerprint, not prefix: enough to tell two keys apart in a trace, and
+    // never more than half the credential — a flat 8 characters was the whole
+    // thing for anything shorter than that.
+    const fp = err.match(/"key_prefix":"([^"]*)"/)?.[1] ?? "";
+    assert.match(fp, /^secret-k…$/);
+    assert.ok(fp.replace("…", "").length <= Math.floor(secret.length / 2),
+      `the fingerprint ${JSON.stringify(fp)} is more than half of a ${secret.length}-char key`);
+
+    const events = err.split("\n").filter((l) => l.startsWith("{")).map((l) => JSON.parse(l));
+    // Not Object.groupBy: that is Node 21+, and this package declares
+    // engines >=18.17 with CI running 18 through 26.
+    const byEvent = events.reduce((acc, e) => {
+      (acc[e.event] ??= []).push(e);
+      return acc;
+    }, {});
+    assert.ok(byEvent.startup, "no startup event");
+    assert.ok(byEvent.http_request, "no http_request event");
+    assert.ok(byEvent.call_received?.[0]?.tool === "search");
+    assert.ok(byEvent.call_returning?.[0]?.handler_ms >= 0, "call_returning lacks handler_ms");
+    const reqEvt = byEvent.request?.[0];
+    assert.equal(reqEvt?.status, 200);
+    assert.match(reqEvt?.socket ?? "", /^(new|reused)$/);
+    for (const e of events) assert.match(e.ts, /^\d{4}-\d{2}-\d{2}T/, "event missing ts");
+  } finally { srv.stop(); up.close(); }
+});
+
+test("SIGTERM drains: in-flight call completes, healthz flips 503, new calls refused, exit 0", async () => {
+  // The rolling-deploy contract. Without it every deploy kills live calls.
+  const http2 = await import("node:http");
+  const upSrv = http2.createServer((_req, res) => {
+    setTimeout(() => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ code: 0, data: { results: [{ title: "slow-ok", url: "http://x" }] }, meta: {} }));
+    }, 1200);
+  });
+  await new Promise((r) => upSrv.listen(0, r));
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${upSrv.address().port}` });
+  try {
+    // Start a call that will still be in flight when SIGTERM lands.
+    const inflight = rpc(srv.port, call(40, "slow"), { "x-api-key": "k" });
+    await new Promise((r) => setTimeout(r, 300));
+
+    srv.child.kill("SIGTERM");
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Readiness must already report draining…
+    const h = await fetch(`http://127.0.0.1:${srv.port}/healthz`);
+    assert.equal(h.status, 503, "healthz must flip to 503 during drain");
+    assert.equal((await h.json()).status, "draining");
+    // …new work must be refused…
+    const refused = await fetch(`http://127.0.0.1:${srv.port}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream", "x-api-key": "k" },
+      body: JSON.stringify(call(41, "new")),
+    });
+    assert.equal(refused.status, 503, "new requests during drain must be refused");
+    await refused.json(); // consume — an unread body raises a late rejection when the child exits
+
+    // …and the in-flight call must still complete successfully.
+    const done = await inflight;
+    assert.notEqual(done.msg.result.isError, true, done.msg.result?.content?.[0]?.text);
+    assert.match(done.msg.result.content[0].text, /slow-ok/);
+
+    assert.equal(await srv.exited, 0, "drained process must exit 0");
+  } finally { srv.stop(); upSrv.close(); }
+});
+
+// ---------------------------------------------------------------------------
+// OAuth surface (A3.5): the trigger that makes clients start OAuth at all.
+// Verified live against a hosted MCP endpoint: without a 401 + WWW-Authenticate,
+// claude.ai treats a server as unauthenticated and never shows consent.
+// ---------------------------------------------------------------------------
+const OAUTH_ENV = {
+  OCTEN_OAUTH_AUTHORIZATION_SERVER: "https://auth.octen.example",
+  OCTEN_MCP_RESOURCE: "https://mcp.octen.example/mcp",
+};
+
+test("with an AS configured, both PRM well-known paths serve the RFC 9728 document", async () => {
+  const srv = await startHttp(OAUTH_ENV);
+  try {
+    for (const p of ["/.well-known/oauth-protected-resource", "/.well-known/oauth-protected-resource/mcp"]) {
+      const res = await fetch(`http://127.0.0.1:${srv.port}${p}`);
+      assert.equal(res.status, 200, p);
+      const doc = await res.json();
+      assert.deepEqual(doc, {
+        resource: "https://mcp.octen.example/mcp",
+        authorization_servers: ["https://auth.octen.example"],
+        scopes_supported: ["mcp:tools"],
+        bearer_methods_supported: ["header"],
+      }, `PRM at ${p} must match RFC 9728 byte-for-byte — aud binding depends on it`);
+    }
+  } finally { srv.stop(); }
+});
+
+test("?login without a credential answers 401 with the challenge pointing at PRM", async () => {
+  const srv = await startHttp(OAUTH_ENV);
+  try {
+    const res = await fetch(`http://127.0.0.1:${srv.port}/mcp?login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify(INIT),
+    });
+    assert.equal(res.status, 401);
+    assert.equal(
+      res.headers.get("www-authenticate"),
+      'Bearer resource_metadata="https://mcp.octen.example/.well-known/oauth-protected-resource/mcp"',
+      "the challenge is how a client finds the AS; a malformed header ends the flow silently"
+    );
+    await res.json();
+  } finally { srv.stop(); }
+});
+
+test("?login challenges even a request that carries a credential", async () => {
+  // Deliberate reversal of what this test used to assert. It pinned "presence
+  // of any credential passes through", which came from the era when `?login`
+  // was the *gate* on the challenge. That gate was removed — an uncredentialed
+  // request is challenged everywhere now — and what `?login` is for afterwards
+  // is the opposite: forcing authorization when a credential IS present. That
+  // is the only route from an already-configured API key to OAuth, because a
+  // key otherwise stops the challenge from ever being sent.
+  const srv = await startHttp(OAUTH_ENV);
+  try {
+    const res = await fetch(`http://127.0.0.1:${srv.port}/mcp?login`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json", Accept: "application/json, text/event-stream",
+        Authorization: "Bearer anything-at-all",
+      },
+      body: JSON.stringify(INIT),
+    });
+    assert.equal(res.status, 401);
+    assert.match(res.headers.get("www-authenticate") ?? "", /resource_metadata=/);
+    await res.text();
+
+    // Reverse case: the plain endpoint must still accept that same credential,
+    // or forcing would just be a blanket refusal.
+    const plain = await fetch(`http://127.0.0.1:${srv.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json", Accept: "application/json, text/event-stream",
+        Authorization: "Bearer anything-at-all",
+      },
+      body: JSON.stringify(INIT),
+    });
+    assert.equal(plain.status, 200);
+    await plain.text();
+  } finally { srv.stop(); }
+});
+
+test("without an AS configured, the OAuth surface does not exist", async () => {
+  // A self-hosted instance must not advertise an authorization server it
+  // does not have — an unusable capability surfaced anywhere misleads.
+  const srv = await startHttp();
+  try {
+    const prm = await fetch(`http://127.0.0.1:${srv.port}/.well-known/oauth-protected-resource`);
+    assert.equal(prm.status, 404);
+    await prm.json();
+    const login = await fetch(`http://127.0.0.1:${srv.port}/mcp?login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify(INIT),
+    });
+    assert.equal(login.status, 200, "?login is inert when no AS is configured");
+  } finally { srv.stop(); }
+});
+
+test("initialize advertises the branding surface (title, websiteUrl, icons)", async () => {
+  const srv = await startHttp();
+  try {
+    const { msg } = await rpc(srv.port, INIT);
+    const info = msg.result.serverInfo;
+    assert.equal(info.title, "Octen");
+    assert.equal(info.websiteUrl, "https://octen.ai");
+    assert.ok(Array.isArray(info.icons) && info.icons[0].src.startsWith("https://octen.ai/"),
+      "directory listings render these fields");
+  } finally { srv.stop(); }
+});

--- a/test/network.test.mjs
+++ b/test/network.test.mjs
@@ -1,0 +1,166 @@
+/**
+ * Real-socket reproductions of the failure shapes from the 0.3.7 field report.
+ *
+ * The in-process suite (http.test.mjs) covers the same code paths with
+ * *simulated* error objects — a stub that throws `{code: "ECONNRESET"}`. That
+ * proves the handling logic, not that real wire behavior produces those
+ * shapes. Each test here builds the failure out of actual TCP sockets and
+ * drives the built server as a separate process.
+ *
+ * What deliberately is NOT here, and why (recorded so nobody "fixes" it):
+ *  - A true SYN-blackhole connect timeout (the reporter's cluster, 12.8s). It
+ *    cannot be simulated deterministically cross-platform: localhost always answers, the
+ *    listen-backlog-saturation trick works on Linux but macOS accepts anyway
+ *    (verified 2026-08-15), and unroutable test IPs are hijacked by VPN/TUN
+ *    setups — which is exactly how this repo's own dev machine behaves. The
+ *    UND_ERR_CONNECT_TIMEOUT handling stays covered by the simulated-error
+ *    tests plus manual live verification.
+ *  - DNS failure (ENOTFOUND): resolver behavior is environment-dependent for
+ *    the same reason.
+ *  - Upstream queueing/relay delay (field report §4.2): not our layer; covered
+ *    by the call_received observability, not by tests.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import http from "node:http";
+
+import { startHttp, rpc, call } from "./helpers.mjs";
+
+/**
+ * Raw TCP upstream that serves connection #1's first request normally, then
+ * RSTs the moment a second request arrives on that same socket — the
+ * keep-alive race: the origin killing a socket exactly as the client
+ * dispatches on it. Every later connection is served normally.
+ */
+function startRstOnReuseServer() {
+  let conns = 0;
+  const srv = net.createServer((sock) => {
+    conns++;
+    const id = conns;
+    let requests = 0;
+    sock.on("data", (d) => {
+      const chunk = d.toString("latin1");
+      if (!chunk.includes("POST ")) return; // body continuation of a parsed request
+      requests++;
+      if (id === 1 && requests >= 2) {
+        sock.resetAndDestroy(); // RST, not FIN — the abrupt variant
+        return;
+      }
+      const body = JSON.stringify({
+        code: 0,
+        data: { results: [{ title: `served-by-conn-${id}`, url: "http://x" }] },
+        meta: {},
+      });
+      sock.write(
+        `HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n` +
+        `Content-Length: ${body.length}\r\nConnection: keep-alive\r\n\r\n${body}`
+      );
+    });
+    sock.on("error", () => {});
+  });
+  return new Promise((resolve) =>
+    srv.listen(0, () => resolve({ port: srv.address().port, close: () => srv.close() })));
+}
+
+test("a socket RST mid-dispatch on a reused connection is rescued by the retry", async () => {
+  // Field report §4.5: every one of their manual retries succeeded. This is that
+  // scenario on real sockets — and the property the retry exists for.
+  const up = await startRstOnReuseServer();
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${up.port}`, OCTEN_MCP_DEBUG: "1" });
+  try {
+    const first = await rpc(srv.port, call(1, "warm"), { "x-api-key": "k" });
+    assert.match(first.msg.result.content[0].text, /served-by-conn-1/);
+
+    const second = await rpc(srv.port, call(2, "reuse"), { "x-api-key": "k" });
+    assert.notEqual(second.msg.result.isError, true,
+      `retry did not rescue the RST: ${second.msg.result.content?.[0]?.text}`);
+    assert.match(second.msg.result.content[0].text, /served-by-conn-2/,
+      "the rescue must have happened on a fresh connection");
+
+    const err = srv.stderr();
+    assert.match(err, /attempt=1 FAILED .*socket=reused/,
+      "the failure must be attributed to the reused socket");
+    assert.match(err, /attempt=2 status=200 .*socket=new/,
+      "the retry must show a fresh connection");
+  } finally { srv.stop(); up.close(); }
+});
+
+test("the same RST without the retry is a real wire failure (harness self-check)", async () => {
+  // Guards the test above against silently stopping to reproduce: if undici
+  // ever absorbs this internally, this companion starts failing and tells us
+  // the scenario — not the retry — went stale.
+  const up = await startRstOnReuseServer();
+  const srv = await startHttp({
+    OCTEN_API_URL: `http://127.0.0.1:${up.port}`, OCTEN_MCP_DEBUG: "1", OCTEN_RETRY: "off",
+  });
+  try {
+    await rpc(srv.port, call(1, "warm"), { "x-api-key": "k" });
+    const second = await rpc(srv.port, call(2, "reuse"), { "x-api-key": "k" });
+    assert.equal(second.msg.result.isError, true,
+      "with the retry off, the RST must surface — otherwise this suite is testing nothing");
+    assert.match(second.msg.result.content[0].text, /ECONNRESET|UND_ERR_SOCKET/);
+  } finally { srv.stop(); up.close(); }
+});
+
+test("an origin that closes idle sockets politely (FIN) costs a reconnect, not an error", async () => {
+  // The graceful sibling of the RST case — and the reason keepAliveTimeout
+  // must sit below the origin's idle limit. A FIN'd socket must be replaced
+  // silently: no failure, no retry, just socket=new on the next call.
+  const upstream = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ code: 0, data: { results: [{ title: "ok", url: "http://x" }] }, meta: {} }));
+  });
+  upstream.keepAliveTimeout = 100; // origin reaps idle sockets fast
+  await new Promise((r) => upstream.listen(0, r));
+  const srv = await startHttp({
+    OCTEN_API_URL: `http://127.0.0.1:${upstream.address().port}`, OCTEN_MCP_DEBUG: "1",
+  });
+  try {
+    const a = await rpc(srv.port, call(1, "a"), { "x-api-key": "k" });
+    assert.notEqual(a.msg.result.isError, true);
+    await new Promise((r) => setTimeout(r, 400)); // outlive the origin's idle limit
+    const b = await rpc(srv.port, call(2, "b"), { "x-api-key": "k" });
+    assert.notEqual(b.msg.result.isError, true);
+    assert.doesNotMatch(srv.stderr(), /FAILED/,
+      "a polite FIN must not surface as a failure anywhere");
+  } finally { srv.stop(); upstream.close(); }
+});
+
+test("[http transport] an upstream that accepts and never answers hits the tool deadline at real elapsed time", async () => {
+  // The in-process suite fakes TimeoutError objects; this one earns it: the
+  // socket connects fine and then nothing ever comes back.
+  const upstream = http.createServer(() => { /* accept, read, say nothing */ });
+  await new Promise((r) => upstream.listen(0, r));
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${upstream.address().port}` });
+  try {
+    const t0 = Date.now();
+    const r = await rpc(srv.port, { jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: "search", arguments: { query: "x", timeout: 2 } } }, { "x-api-key": "k" });
+    const elapsed = Date.now() - t0;
+    assert.equal(r.msg.result.isError, true);
+    assert.match(r.msg.result.content[0].text, /timed out after 2s/);
+    assert.ok(elapsed >= 1900 && elapsed < 8000, `deadline fired at ${elapsed}ms, expected ~2000ms`);
+  } finally { srv.stop(); upstream.close(); }
+});
+
+test("[http transport] a stalled response body is reported as a timeout, not as malformed JSON", async () => {
+  // Found while writing this suite: headers 200 arrive, the body stalls, the
+  // deadline aborts the body read — and the old catch reported "returned
+  // non-JSON (HTTP 200)", sending whoever reads the error hunting for a
+  // serialization bug instead of a stalled connection.
+  const upstream = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.write('{"code":0,"data":{"resul'); // half a body, then silence
+  });
+  await new Promise((r) => upstream.listen(0, r));
+  const srv = await startHttp({ OCTEN_API_URL: `http://127.0.0.1:${upstream.address().port}` });
+  try {
+    const r = await rpc(srv.port, { jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: "search", arguments: { query: "x", timeout: 2 } } }, { "x-api-key": "k" });
+    assert.equal(r.msg.result.isError, true);
+    const text = r.msg.result.content[0].text;
+    assert.match(text, /timed out while reading the response body \(HTTP 200\)/, `got: ${text}`);
+    assert.doesNotMatch(text, /non-JSON/, "a stalled stream must not be misreported as malformed JSON");
+  } finally { srv.stop(); upstream.close(); }
+});

--- a/test/oauthRs.test.mjs
+++ b/test/oauthRs.test.mjs
@@ -1,0 +1,232 @@
+/**
+ * Resource-server side of OAuth (spec §A3), against a real mini
+ * authorization-server: an in-test RSA keypair served over a live JWKS
+ * endpoint, RS256 tokens minted with node:crypto, and a resolve-key stub that
+ * enforces the X-Octen-Service-Token header — the same contract the real AS
+ * implements (read from its source, fosite v0.49 + grant_id claim).
+ *
+ * The failure split is the point under test (spec §A3.5): token problems must
+ * be transport-level 401 + WWW-Authenticate (clients auto-refresh on it — an
+ * isError tool result breaks that loop), while backend unavailability must be
+ * 503 (the token may be fine; a client that burns its refresh flow on our
+ * outage gets logged out for nothing).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+
+import { startHttp, startUpstream, call } from "./helpers.mjs";
+
+// ---- mini authorization server ----------------------------------------------
+
+const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const KID = "test-kid-1";
+
+const b64url = (buf) => Buffer.from(buf).toString("base64url");
+
+function mint({ kid = KID, alg = "RS256", ...claims }) {
+  const header = b64url(JSON.stringify({ alg, kid, typ: "JWT" }));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = b64url(JSON.stringify({
+    iat: now, exp: now + 3600, jti: `jti-${Math.random()}`, ...claims,
+  }));
+  const sig = cryptoSign("sha256", Buffer.from(`${header}.${payload}`), privateKey);
+  return `${header}.${payload}.${b64url(sig)}`;
+}
+
+/** JWKS + resolve-key in one process, with hit counters the tests assert on. */
+function startAs({ serviceToken = "svc-secret" } = {}) {
+  const hits = { jwks: 0, resolve: 0 };
+  const revoked = new Set(["revoked-grant"]);
+  const srv = http.createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/api/oauth/jwks") {
+      hits.jwks++;
+      const jwk = publicKey.export({ format: "jwk" });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ keys: [{ ...jwk, kid: KID, use: "sig", alg: "RS256" }] }));
+      return;
+    }
+    if (req.method === "POST" && req.url === "/internal/oauth/resolve-key") {
+      hits.resolve++;
+      if (req.headers["x-octen-service-token"] !== serviceToken) {
+        res.writeHead(401); res.end(); return;
+      }
+      let body = "";
+      req.on("data", (d) => (body += d));
+      req.on("end", () => {
+        const { grant_id } = JSON.parse(body);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(revoked.has(grant_id)
+          ? JSON.stringify({ active: false })
+          : JSON.stringify({ active: true, api_key: `resolved-key-for-${grant_id}`, account_type: "user", account_id: "u1" }));
+      });
+      return;
+    }
+    res.writeHead(404); res.end();
+  });
+  return new Promise((resolve) => srv.listen(0, () => resolve({
+    port: srv.address().port, hits, close: () => srv.close(),
+    issuer: `http://127.0.0.1:${srv.address().port}`,
+  })));
+}
+
+const RESOURCE = "https://mcp.octen.example/mcp";
+
+async function startStack(extraEnv = {}) {
+  const as = await startAs();
+  const up = await startUpstream();
+  const srv = await startHttp({
+    OCTEN_API_URL: `http://127.0.0.1:${up.port}`,
+    OCTEN_OAUTH_AUTHORIZATION_SERVER: as.issuer,
+    OCTEN_MCP_RESOURCE: RESOURCE,
+    OCTEN_OAUTH_RESOLVE_URL: `${as.issuer}/internal/oauth/resolve-key`,
+    OCTEN_OAUTH_RESOLVE_TOKEN: "svc-secret",
+    OCTEN_MCP_DEBUG: "1",
+    ...extraEnv,
+  });
+  return { as, up, srv, stop: () => { srv.stop(); up.close(); as.close(); } };
+}
+
+/** POST a tool call with a Bearer token; return {status, headers, msg}. */
+async function bearerCall(port, token, id = 2) {
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(call(id, "q")),
+  });
+  const text = await res.text();
+  const data = text.split("\n").filter((l) => l.startsWith("data: ")).pop();
+  return {
+    status: res.status,
+    wwwAuth: res.headers.get("www-authenticate"),
+    msg: data ? JSON.parse(data.slice(6)) : (text ? JSON.parse(text) : undefined),
+  };
+}
+
+function validClaims(as, grant = "grant-abc") {
+  return { iss: as.issuer, aud: [RESOURCE], scp: ["mcp:tools"], sub: "u1", grant_id: grant };
+}
+
+// ------------------------------------------------------------------------------
+
+test("a valid access token is exchanged for the grant's API key before dispatch", async () => {
+  const stack = await startStack();
+  try {
+    const r = await bearerCall(stack.srv.port, mint(validClaims(stack.as)));
+    assert.equal(r.status, 200);
+    assert.notEqual(r.msg.result.isError, true, r.msg.result?.content?.[0]?.text);
+    // The upstream must have been called with the RESOLVED key, not the JWT.
+    assert.deepEqual(stack.up.seenKeys, ["resolved-key-for-grant-abc"]);
+    assert.ok(stack.as.hits.resolve >= 1, "resolve-key endpoint was never consulted");
+  } finally { stack.stop(); }
+});
+
+test("an expired token is a transport 401 with a challenge — never a tool-result error", async () => {
+  const stack = await startStack();
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const r = await bearerCall(stack.srv.port, mint({ ...validClaims(stack.as), exp: now - 120 }));
+    assert.equal(r.status, 401, "clients auto-refresh on 401; an isError breaks that loop");
+    assert.match(r.wwwAuth ?? "", /invalid_token/);
+    assert.match(r.wwwAuth ?? "", /resource_metadata="https:\/\/mcp\.octen\.example\/\.well-known\/oauth-protected-resource\/mcp"/);
+    assert.equal(stack.up.seenKeys.length, 0, "an invalid token must never reach the upstream");
+  } finally { stack.stop(); }
+});
+
+test("exp within the 60s clock tolerance still passes", async () => {
+  const stack = await startStack();
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const r = await bearerCall(stack.srv.port, mint({ ...validClaims(stack.as), exp: now - 30 }));
+    assert.equal(r.status, 200, "AS/RS clock skew below tolerance must not log users out");
+  } finally { stack.stop(); }
+});
+
+test("audience, issuer, and scope are each enforced byte-for-byte", async () => {
+  const stack = await startStack();
+  try {
+    const cases = [
+      { ...validClaims(stack.as), aud: ["https://mcp.octen.example/mcp/"] }, // trailing slash
+      { ...validClaims(stack.as), iss: `${stack.as.issuer}/` },
+      { ...validClaims(stack.as), scp: ["something:else"] },
+      { ...validClaims(stack.as), grant_id: undefined },
+    ];
+    for (const claims of cases) {
+      const r = await bearerCall(stack.srv.port, mint(claims));
+      assert.equal(r.status, 401, `claims ${JSON.stringify(claims).slice(0, 90)} must be rejected`);
+    }
+    assert.equal(stack.up.seenKeys.length, 0);
+  } finally { stack.stop(); }
+});
+
+test("an unknown kid triggers exactly one JWKS refetch before rejecting (rotation path)", async () => {
+  // A short window rather than the 10s default: the point under test is that
+  // the refetch still happens once the window passes, not how long it is.
+  const stack = await startStack({ OCTEN_JWKS_REFETCH_COOLDOWN_MS: "50" });
+  try {
+    await bearerCall(stack.srv.port, mint(validClaims(stack.as))); // primes the JWKS cache
+    await new Promise((r) => setTimeout(r, 80));
+    const before = stack.as.hits.jwks;
+    const r = await bearerCall(stack.srv.port, mint({ ...validClaims(stack.as), kid: "freshly-rotated" }));
+    assert.equal(r.status, 401);
+    assert.equal(stack.as.hits.jwks, before + 1,
+      "a just-published kid must get one refetch — zero breaks rotation, unbounded is a DoS lever");
+  } finally { stack.stop(); }
+});
+
+test("a revoked grant is a 401 (re-authorize), not a 503", async () => {
+  const stack = await startStack();
+  try {
+    const r = await bearerCall(stack.srv.port, mint(validClaims(stack.as, "revoked-grant")));
+    assert.equal(r.status, 401, "revocation means the client must re-authorize — 503 would make it retry forever");
+    assert.equal(stack.up.seenKeys.length, 0);
+  } finally { stack.stop(); }
+});
+
+test("resolve-key backend down is a 503, not a 401 — the token may be fine", async () => {
+  const as = await startAs();
+  const up = await startUpstream();
+  const srv = await startHttp({
+    OCTEN_API_URL: `http://127.0.0.1:${up.port}`,
+    OCTEN_OAUTH_AUTHORIZATION_SERVER: as.issuer,
+    OCTEN_MCP_RESOURCE: RESOURCE,
+    OCTEN_OAUTH_RESOLVE_URL: "http://127.0.0.1:45996/internal/oauth/resolve-key", // nothing there
+    OCTEN_OAUTH_RESOLVE_TOKEN: "svc-secret",
+  });
+  try {
+    const r = await bearerCall(srv.port, mint(validClaims(as)));
+    assert.equal(r.status, 503, "a 401 here would make clients burn their refresh flow on our outage");
+    // Says which dependency and why. "temporarily unavailable" on its own fits
+    // every cause equally and is what made the earlier reports unactionable.
+    assert.match(r.msg.error.message, /grant-resolution service/);
+    assert.match(r.msg.error.message, /ECONNREFUSED|ECONNRESET|EHOSTUNREACH|no response within/);
+    assert.match(r.msg.error.message, /retry shortly rather than re-authorizing/);
+  } finally { srv.stop(); up.close(); as.close(); }
+});
+
+test("the resolved key is cached: two calls on one grant hit resolve-key once", async () => {
+  const stack = await startStack();
+  try {
+    await bearerCall(stack.srv.port, mint(validClaims(stack.as)), 2);
+    await bearerCall(stack.srv.port, mint(validClaims(stack.as)), 3);
+    assert.equal(stack.as.hits.resolve, 1, "resolve-key sits on the hot path; the 60s cache is the SLA backstop");
+    assert.equal(stack.up.seenKeys.length, 2);
+  } finally { stack.stop(); }
+});
+
+test("bare API keys never enter the OAuth path even with it fully configured", async () => {
+  const stack = await startStack();
+  try {
+    const r = await bearerCall(stack.srv.port, "octen-plain-api-key-123");
+    assert.equal(r.status, 200);
+    assert.deepEqual(stack.up.seenKeys, ["octen-plain-api-key-123"],
+      "a bare key must pass through verbatim — the two credential forms share one header");
+    assert.equal(stack.as.hits.jwks + stack.as.hits.resolve, 0,
+      "no OAuth endpoint may be consulted for a non-JWT credential");
+  } finally { stack.stop(); }
+});

--- a/test/search.test.mjs
+++ b/test/search.test.mjs
@@ -142,3 +142,232 @@ test("broad_search: search_options omitted when no per-sub-query options set", a
   await handleBroadSearch({ query: "ev charging networks" });
   assert.equal("search_options" in captured.body, false);
 });
+
+// ---- Media fields in the rendered result -------------------------------------
+//
+// `include_images` costs the caller an upstream fetch and
+// promise, in the tool's own description, to "return media URLs per result".
+// Two ways that promise was broken, both measured against the live API:
+// `cover_image` is `{url, description}` and was interpolated as an object, so
+// every result carrying one printed `[object Object]`; and the `images` /
+// `videos` arrays were rendered as a bare count, so a result with 101 image
+// URLs produced the text "**Images:** 101" and not one usable link.
+
+/** A result shaped like the API's, with `n` images. */
+const resultWithMedia = (n) => ({
+  code: 0,
+  data: {
+    results: [{
+      title: "T", url: "https://example.com/page",
+      cover_image: { url: "https://cdn.example.com/cover.jpg", description: "Cover" },
+      images: Array.from({ length: n }, (_, i) => ({
+        url: `https://cdn.example.com/img${i}.jpg`, description: `caption ${i}`,
+      })),
+      videos: [{ url: "https://cdn.example.com/clip.mp4", description: "clip" }],
+    }],
+  },
+});
+
+test("cover_image renders its URL, not the object it arrives as", async () => {
+  captureFetch(resultWithMedia(2));
+  const out = (await handleSearch({ query: "q", include_images: true })).content[0].text;
+  assert.doesNotMatch(out, /\[object Object\]/, "the object was interpolated instead of its url");
+  assert.match(out, /\*\*Cover image:\*\* https:\/\/cdn\.example\.com\/cover\.jpg/);
+});
+
+test("image and video URLs are printed, not just counted", async () => {
+  captureFetch(resultWithMedia(3));
+  // No `include_videos` on search — the API reference documents none, so the
+  // tool does not advertise one. The renderer is still exercised: a response
+  // carrying `videos` must not have them dropped.
+  const out = (await handleSearch({ query: "q", include_images: true })).content[0].text;
+  for (let i = 0; i < 3; i++) {
+    assert.match(out, new RegExp(`- https://cdn\\.example\\.com/img${i}\\.jpg`),
+      `image ${i}'s URL is missing — a count is not something a caller can act on`);
+  }
+  assert.match(out, /- https:\/\/cdn\.example\.com\/clip\.mp4/);
+  // The count is still useful; it just cannot be the whole answer.
+  assert.match(out, /\*\*Images:\*\* 3/);
+});
+
+test("a long media list is capped, and says how many were left out", async () => {
+  // 101 was the real number from one search. Pasting them all into a model's
+  // context costs more than the answer is worth — but dropping them silently
+  // is how this got broken in the first place, so the total has to be stated.
+  captureFetch(resultWithMedia(101));
+  const out = (await handleSearch({ query: "q", include_images: true })).content[0].text;
+  const listed = (out.match(/^- https:\/\/cdn\.example\.com\/img\d+\.jpg —/gm) ?? []).length;
+  assert.equal(listed, 10, `printed ${listed} of 101 URLs`);
+  assert.match(out, /\*\*Images:\*\* 101 — first 10:/, "a cap the reader cannot see is a silent drop");
+});
+
+test("malformed or absent media does not produce empty or broken lines", async () => {
+  captureFetch({
+    code: 0,
+    data: {
+      results: [{
+        title: "T", url: "https://example.com/",
+        cover_image: {},                       // present but no url
+        images: [{ description: "no url" }],   // entries without urls
+        videos: [],
+      }],
+    },
+  });
+  const out = (await handleSearch({ query: "q", include_images: true })).content[0].text;
+  assert.doesNotMatch(out, /Cover image/, "an object with no url must not render a label");
+  assert.doesNotMatch(out, /\*\*Images:\*\*/, "entries with no url leave nothing to list");
+  assert.doesNotMatch(out, /undefined|\[object Object\]/);
+});
+
+test("extract renders media the same way search does", async () => {
+  // The two rendered media differently — extract handled `cover_image`
+  // correctly while search did not, and both printed bare counts. They share
+  // one renderer now; this fails if a second copy reappears.
+  const { handleExtract } = await import("../dist/extract.js");
+  captureFetch({
+    code: 0,
+    data: {
+      results: [{
+        url: "https://example.com/a", title: "T",
+        cover_image: { url: "https://cdn.example.com/cover.jpg" },
+        images: [{ url: "https://cdn.example.com/i0.jpg" }, { url: "https://cdn.example.com/i1.jpg" }],
+        videos: [{ url: "https://cdn.example.com/v0.mp4" }],
+        audio: [{ url: "https://cdn.example.com/a0.mp3" }],
+      }],
+    },
+  });
+  const out = (await handleExtract({
+    urls: ["https://example.com/a"], include_images: true, include_videos: true, include_audio: true,
+  })).content[0].text;
+  for (const u of ["cover.jpg", "i0.jpg", "i1.jpg", "v0.mp4", "a0.mp3"]) {
+    assert.match(out, new RegExp(u.replace(".", "\\.")), `${u} was dropped`);
+  }
+  assert.doesNotMatch(out, /\[object Object\]/);
+});
+
+test("each media entry carries its caption, not just its URL", async () => {
+  // The caption is the point on news results: it carries what was
+  // photographed, where, when, and the photographer's credit. A bare link
+  // leaves the model with nothing it can say about the picture.
+  captureFetch(resultWithMedia(2));
+  const out = (await handleSearch({ query: "q", include_images: true })).content[0].text;
+  assert.match(out, /- https:\/\/cdn\.example\.com\/img0\.jpg — caption 0/);
+  assert.match(out, /- https:\/\/cdn\.example\.com\/img1\.jpg — caption 1/);
+  assert.match(out, /\*\*Cover image:\*\* https:\/\/cdn\.example\.com\/cover\.jpg — Cover/);
+});
+
+test("a media entry with no caption renders as a bare URL, with no dangling separator", async () => {
+  captureFetch({
+    code: 0,
+    data: {
+      results: [{
+        title: "T", url: "https://example.com/",
+        cover_image: { url: "https://cdn.example.com/c.jpg" },          // no description
+        images: [{ url: "https://cdn.example.com/i.jpg", description: "   " }], // blank one
+      }],
+    },
+  });
+  const out = (await handleSearch({ query: "q", include_images: true })).content[0].text;
+  assert.match(out, /\*\*Cover image:\*\* https:\/\/cdn\.example\.com\/c\.jpg$/m);
+  assert.match(out, /- https:\/\/cdn\.example\.com\/i\.jpg$/m);
+  assert.doesNotMatch(out, /—\s*$/m, "a missing caption must not leave a trailing dash");
+});
+
+// ---- image_search takes exactly one input ------------------------------------
+//
+// The API's `inputs` array is documented `maxItems: 1` — "Currently only a
+// single input is supported: either one text input or one image input." The
+// tool used to require `query` and describe `image_url` as usable "in addition"
+// to it, which inverted both halves of that rule: the combination it advertised
+// was refused upstream with `Invalid params. Inputs exceeds 1 entries`, while
+// the documented image-only search could not be expressed at all.
+
+test("image_search sends exactly one input, text or image", async () => {
+  const { handleImageSearch } = await import("../dist/imageSearch.js");
+
+  let cap = captureFetch();
+  await handleImageSearch({ query: "dog" });
+  assert.deepEqual(cap.body.inputs, [{ type: "text", data: "dog" }]);
+
+  cap = captureFetch();
+  await handleImageSearch({ image_url: "https://cdn.example.com/a.jpg" });
+  assert.deepEqual(cap.body.inputs, [{ type: "image", url: "https://cdn.example.com/a.jpg" }],
+    "an image-only search is documented and must be reachable");
+});
+
+test("image_search refuses both inputs, and refuses neither", async () => {
+  const { handleImageSearch } = await import("../dist/imageSearch.js");
+
+  // Every pair, and the triple: the rule is "exactly one", so each way of
+  // breaking it has to be caught, and the message has to name what was sent.
+  for (const args of [
+    { query: "dog", image_url: "https://cdn.example.com/a.jpg" },
+    { query: "dog", image_data: "AAAA" },
+    { image_url: "https://cdn.example.com/a.jpg", image_data: "AAAA" },
+    { query: "dog", image_url: "https://cdn.example.com/a.jpg", image_data: "AAAA" },
+  ]) {
+    const cap = captureFetch();
+    const out = await handleImageSearch(args);
+    assert.equal(out.isError, true, `${Object.keys(args).join("+")} must be refused`);
+    assert.match(out.content[0].text, /exactly one of/);
+    for (const k of Object.keys(args)) {
+      assert.match(out.content[0].text, new RegExp("`" + k + "`"),
+        `the refusal must name ${k}, which the caller actually sent`);
+    }
+    assert.equal(cap.body, undefined, "a refused call must not reach the API");
+  }
+
+  const neither = await handleImageSearch({ count: 3 });
+  assert.equal(neither.isError, true);
+  for (const k of ["query", "image_url", "image_data"]) {
+    assert.match(neither.content[0].text, new RegExp("`" + k + "`"),
+      "with nothing given, the message must name every way to satisfy it");
+  }
+});
+
+test("image_search's schema stops requiring query", async () => {
+  const { imageSearchTool } = await import("../dist/imageSearch.js");
+  assert.equal(imageSearchTool.inputSchema.required, undefined,
+    "requiring `query` made the documented image-only search unreachable");
+  for (const f of ["query", "image_url", "image_data"]) {
+    assert.match(imageSearchTool.inputSchema.properties[f].description, /[Ee]xactly one of/,
+      `${f} must say it cannot be combined with the others`);
+  }
+  // The documented ceiling is on the encoded string, not on the picture.
+  assert.equal(imageSearchTool.inputSchema.properties.image_data.maxLength, 5 * 1024 * 1024);
+  assert.doesNotMatch(imageSearchTool.description, /optionally (an|by a) .?image/i,
+    "the description must not suggest a reference image can be added to a text query");
+});
+
+test("image_data accepts a data: URI by using its payload", async () => {
+  // What every browser and screenshot tool produces. The payload *is* the
+  // base64 the API wants, so refusing the container would be pedantry — but it
+  // must be unwrapped, or the API sees `data:image/png;base64,…` as the image.
+  const { handleImageSearch } = await import("../dist/imageSearch.js");
+  const B64 = "iVBORw0KGgoAAAANSUhEUg==";
+  for (const given of [B64, `data:image/png;base64,${B64}`, `  ${B64}  `]) {
+    const cap = captureFetch();
+    await handleImageSearch({ image_data: given });
+    assert.deepEqual(cap.body.inputs, [{ type: "image", data: B64 }],
+      `the API must receive the payload alone, got it from ${JSON.stringify(given.slice(0, 30))}`);
+  }
+});
+
+test("an empty image_search result names the input that was actually used", async () => {
+  // `No image results for "undefined"` reads like the caller passed a broken
+  // argument, when in fact the search ran and found nothing. It appeared the
+  // moment `query` stopped being required.
+  const { handleImageSearch } = await import("../dist/imageSearch.js");
+  const cases = [
+    [{ query: "dog" }, /"dog"/],
+    [{ image_url: "https://cdn.example.com/a.jpg" }, /https:\/\/cdn\.example\.com\/a\.jpg/],
+    [{ image_data: "AAAA" }, /the supplied image/],
+  ];
+  for (const [args, expected] of cases) {
+    captureFetch({ code: 0, data: { results: [] } });
+    const out = await handleImageSearch(args);
+    assert.match(out.content[0].text, expected);
+    assert.doesNotMatch(out.content[0].text, /undefined/,
+      `${Object.keys(args)[0]} produced an undefined in the empty-result message`);
+  }
+});


### PR DESCRIPTION
Adds `octen-mcp-http`: the same tools behind a URL, so a deployment we operate can serve clients that today each spawn a local Node process. Both entry points assemble the server from `src/server.ts`, so the transports cannot drift, and the stdio entry keeps its behaviour.

Ships as **0.5.0**.

## Transport

Stateless — one Server + transport pair per POST, torn down with the response. Every tool is single-shot, so there is no session worth holding and scaling stays a matter of adding instances.

Credentials are enforced at `tools/call`, not at the door. `initialize` and `tools/list` succeed without one, so a client can connect and show the tools before a key is configured, and a wrong key fails at call time with an error that says what to fix. The missing-key message is transport-aware — an HTTP caller is told about headers, not about an env var it does not have.

Three credential spellings: `x-api-key`, `Authorization: Bearer`, and `?octenApiKey=`. Some clients can only send the second; the third exists for clients that cannot set a header at all, and ranks last so a header-capable client is never downgraded.

A key in a URL reaches proxy logs and browser history, which we do not control. What we do control is our own logging, so `redactUrl` replaces every query **value** whole — not truncated, since a truncated credential is still a usable prefix while looking handled — and replaces all parameters rather than a maintained list of key names, so a parameter added later is masked before anyone remembers this code exists.

The key travels per request, bound by closure into a per-request server. `OCTEN_API_KEY` is deliberately **not** a fallback for HTTP callers: one process serves many tenants, and an unauthenticated request must fail rather than silently ride the deployment's own credential. The first draft had exactly that leak; the test written to forbid it caught it.

## OAuth resource server

RS256 verification against a JWKS, RFC 9728 protected-resource metadata on both well-known paths, RFC 8707 audience binding compared byte-for-byte, and grant-for-key exchange.

Clients begin OAuth from a `401` + `WWW-Authenticate`, so that challenge is the default answer when no credential is present — a server that always returns `200` reads as unauthenticated and never produces a consent screen. `/mcp/oauth` and `?login` force the challenge even when a credential *is* present, which is the only route for someone who already has an API key configured and wants to move to OAuth.

The whole surface stays off unless both `OCTEN_OAUTH_AUTHORIZATION_SERVER` and `OCTEN_MCP_RESOURCE` are set: an instance without an authorization server must not advertise one. The resource URL is explicit configuration rather than derived — behind a fronting proxy it cannot be recovered from the socket, and the audience comparison needs it exactly.

## Security fixes found while building this

| | |
|---|---|
| **Remote process kill, unauthenticated** | A `kid` containing CRLF reached a header. One request killed the process. |
| **Chunked bodies bypassed the size cap entirely** | The cap read `Content-Length`; a chunked request has none. Now counts actual bytes. |
| **Concurrent large bodies could exhaust memory** | `OCTEN_MCP_MAX_INFLIGHT_BODY` bounds the total across requests. The charge is released on `res.close`, not at read-end — releasing early let 40 concurrent requests reach 1 GB. |
| **JWKS amplification against our own authorization server** | An unknown `kid` triggered a refetch per request. Now coalesced behind a cooldown. |
| **Prototype-chain bypass of argument validation** | `in` accepted inherited properties; `Object.hasOwn` does not. |
| **A 413 could arrive as a TCP reset** | The client saw a connection failure instead of the reason. |
| **Unverifiable JWTs were retried as API keys** | A structurally-valid token that failed verification fell through to the key path. |

## Schemas match the API reference

Seven declared limits disagreed with the published API — two of them **rejecting calls the API accepts**. Each was checked against the live endpoint rather than the docs:

- domain filters take 1200 entries of up to 60 characters (was 1000/150 × 30)
- `include_videos` is gone from search — the reference does not document it
- `image_search` takes **exactly one** input: a text query, an image URL, or base64 `image_data` — never more than one, which is what the endpoint accepts. It previously advertised the one combination the API refuses.
- the three time parameters `image_search` offered do not exist on that endpoint; it returns `200` with unfiltered results rather than an error, so a time-scoped image search failed silently

`include_images` / `include_videos` now actually return URLs with their captions, and `cover_image` no longer renders as `[object Object]`.

The HTTP body cap defaults to **6 MiB** so 5 MB base64 image input works out of the box, with the inflight budget keeping concurrency from turning that into an OOM.

## Testing

177 tests, including adversarial and real-socket network-failure cases. The fixes above each have a test proven to fail against the unfixed code — several rounds of that turned up weak tests of my own (a drain test that killed an idle process, a concurrency test whose requests never actually overlapped, an assertion made vacuous by a stub that recorded nothing).

Tenant isolation is guarded twice: a concurrent-tenants test pins the observable contract, but the race window for shared-key-state bugs sits inside the body-read await, where `Promise.all` cannot reliably land — a mutation storing the key in module state survived it. A second test constructs the interleaving deterministically and fails against that mutation.

## Notes for review

**The feature arrives as one commit.** It was 29; the earlier messages and intermediate trees carried material that does not belong in a public repository, and rewriting them piecemeal would have produced meaningless diffs (one commit's entire content was the removal of a string that would no longer have existed). The original history is archived internally, including the mapping for the pre-release ACR image tags whose SHAs no longer exist here.

The two CI commits on top are separate concerns and reviewable on their own.

**Image builds are now a workflow.** There was none: all ten tags in `service/octen-mcp` were pushed by hand, and the newest sat thirteen commits behind this branch — an image predating base64 image input, the 6 MiB body cap and the schema alignment, while reading as the latest one. The workflow builds, smoke-tests and pushes; `workflow_dispatch` can build any branch, with a checkbox to stop before pushing. It is deliberately not triggered by `pull_request`, because this repository is public and a job holding registry credentials has no business running on a proposed change.

Credentials are a registry token scoped to this one repository, not the registry-wide credentials used elsewhere — verified by confirming it can push `service/octen-mcp` and is refused on `service/apt-app-server` with `insufficient_scope`.

The platform is pinned to `linux/amd64` and asserted in its own step. The smoke test cannot catch a wrong architecture: running the container on the machine that built it succeeds exactly when the two agree, which is how an arm64 image reached the registry having passed every check and then failed at pull time with `no match for platform in manifest`.

**Deployment manifests are not in this repo.** They name internal topology; they live with the deployment spec. The pod's `terminationGracePeriodSeconds` must exceed the longest tool budget (`broad_search`: 300s) or the drain is pointless.

**Not yet verified by a human:** the browser OAuth round trip and token refresh. Everything testable at the protocol level is covered — challenge headers, JWT verification, JWKS rotation, revocation propagation — but the actual consent-screen experience in a real client needs someone to walk through it.
