### PR TITLE
docs: Claude Desktop takes the URL directly, no bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,36 @@ not `url`:
 }
 ```
 
-**Clients that only speak stdio** (Claude Desktop, Zed, Warp, Raycast, Cline)
-reach a remote server through the `mcp-remote` bridge. Note there is **no space
-after the colon** in `--header` — the value is split on the first one:
+**Claude Desktop** takes the URL directly — no config file, no bridge. In
+**Settings → Connectors**, click **Add custom connector**, name it `Octen`, and
+enter:
+
+```
+https://mcp.octen.ai/mcp
+```
+
+Leave the Advanced settings empty: the OAuth Client ID and Secret fields are
+for servers that cannot register a client on their own, and ours can. Claude
+will offer to sign you in, and an Octen key is issued to that connection when
+you approve.
+
+The connector dialog has no field for request headers, so an **API key** goes
+in the URL instead:
+
+```
+https://mcp.octen.ai/mcp?octenApiKey=your-key-here
+```
+
+Signing in is the better of the two — a URL is not a secret-carrying medium,
+and the sign-in flow can be revoked from your account without editing anything
+on this side. Note also that Claude connects from Anthropic's servers rather
+than from your machine, so a self-hosted deployment has to be reachable from
+the public internet for this to work at all; a private one wants the bridge
+below.
+
+**Clients that only speak stdio** (Zed, Warp, Raycast, Cline) reach a remote
+server through the `mcp-remote` bridge. Note there is **no space after the
+colon** in `--header` — the value is split on the first one:
 
 ```json
 {
@@ -211,11 +238,11 @@ that quietly comes up short.
 | Gemini CLI | `gemini mcp add octen -e OCTEN_API_KEY=your-key-here -- npx -y octen-mcp` |
 | VS Code | `code --add-mcp '{"name":"octen","command":"npx","args":["-y","octen-mcp"],"env":{"OCTEN_API_KEY":"your-key-here"}}'` (or click a badge above) |
 | Cursor | [Add to Cursor](https://cursor.com/en/install-mcp?name=octen&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIm9jdGVuLW1jcCJdLCJlbnYiOnsiT0NURU5fQVBJX0tFWSI6InlvdXIta2V5LWhlcmUifX0%3D) (then edit the key), or use the JSON above in `~/.cursor/mcp.json` |
-| Claude Desktop | No CLI — add the JSON above to the config file (see below) |
+| Claude Desktop | No CLI. For the hosted endpoint use **Settings → Connectors → Add custom connector** (above); for a local install, the config file (below) |
 
 ### Config file locations
 
-- **Claude Desktop**: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
+- **Claude Desktop**: `~/Library/Application\ Support/Claude/claude_desktop_config.json` — only needed for a local (stdio) install; the hosted endpoint is added as a connector instead
 - **Cursor**: `~/.cursor/mcp.json`
 - **VS Code workspace**: `.vscode/mcp.json` (use `servers` instead of `mcpServers`)
 - **Windsurf**: `~/.codeium/windsurf/mcp_config.json`


### PR DESCRIPTION
The install docs list Claude Desktop among the stdio-only clients and send readers to `mcp-remote`. It has custom connectors: **Settings → Connectors → Add custom connector**, paste the URL, done.

Telling people to install a bridge they do not need is the worst kind of documentation error — it works, so nobody finds out it was unnecessary.

This was written for #21 but landed after that PR was merged, so it comes separately.

## Two details decide what the instructions say

Both checked against the live endpoint rather than assumed.

**The client ID and secret can be left blank.** `auth.octen.ai` advertises a `registration_endpoint`, so clients register themselves. Documenting those fields as something to fill in would have sent everyone looking for credentials that do not need to exist.

```
POST /mcp with no credential
  -> 401, WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource/mcp"
GET that metadata
  -> authorization_servers: ["https://auth.octen.ai"]
GET https://auth.octen.ai/.well-known/oauth-authorization-server
  -> registration_endpoint: https://auth.octen.ai/api/oauth/register
```

**The connector dialog has no field for request headers.** It offers a name, a URL, and an OAuth client ID/secret — nothing else. So an API key has to travel in the query string, which is exactly what that credential form exists for:

```
https://mcp.octen.ai/mcp?octenApiKey=…   ->  200, six tools
```

Signing in is recommended over it in the text: a URL is not a secret-carrying medium, and a grant can be revoked without touching this side.

## Also recorded

Claude connects from Anthropic's infrastructure rather than the reader's machine, so a self-hosted deployment has to be reachable from the public internet for a connector to work at all. Without that sentence, a self-hoster on a private network reads the failure as our server being broken. For those, the bridge is still the answer.

`mcp-remote` stays documented for Zed, Warp, Raycast and Cline. **I did not verify those four** — Claude Desktop was removed from the list because it was checked, not because the others were.

177 tests pass, including the README consistency check in `docs.test.mjs`.