### PR TITLE
chore: 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octen-mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octen-mcp",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "octen-mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "mcpName": "io.github.Octen-Team/octen-mcp",
-  "description": "MCP server for Octen \u2014 web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
+  "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",
   "author": "Octen <hello@octen.ai>",
   "homepage": "https://github.com/Octen-Team/octen-mcp#readme",


### PR DESCRIPTION
Patch release: explicit MCP tool annotations on every tool + the plugin-directory domain-verification challenge route (#23).

Tagging `v0.5.1` after this merges fires both pipelines: npm publish (stdio users get the annotations too) and the ACR image build (`:SHA` + `:v0.5.1`) for the mcp.octen.ai redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)