### PR TITLE
feat(tools): human-readable titles on every tool (0.5.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "octen-mcp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "octen-mcp",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octen-mcp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "mcpName": "io.github.Octen-Team/octen-mcp",
   "description": "MCP server for Octen — web search plus URL extract: LLM-ready markdown with query-driven highlights, category, and page_structure classification.",
   "license": "MIT",

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -28,10 +28,12 @@ const EXTRACT_CLIENT_TIMEOUT_CAP_SEC = 180;
 /** Tool advertisement — clients see this in the list-tools response. */
 export const extractTool: Tool = {
   name: "extract",
+  title: "URL Extract",
   // Explicit MCP tool annotations: every Octen tool is a read-only query
   // against the open web — it fetches and never mutates external state.
   // Plugin-directory reviews require these three hints on every tool.
   annotations: {
+    title: "URL Extract",
     readOnlyHint: true,
     openWorldHint: true,
     destructiveHint: false,

--- a/src/imageSearch.ts
+++ b/src/imageSearch.ts
@@ -25,10 +25,12 @@ const API_KEY = process.env.OCTEN_API_KEY;
 /** Tool advertisement — clients see this in the list-tools response. */
 export const imageSearchTool: Tool = {
   name: "image_search",
+  title: "Image Search",
   // Explicit MCP tool annotations: every Octen tool is a read-only query
   // against the open web — it fetches and never mutates external state.
   // Plugin-directory reviews require these three hints on every tool.
   annotations: {
+    title: "Image Search",
     readOnlyHint: true,
     openWorldHint: true,
     destructiveHint: false,

--- a/src/search.ts
+++ b/src/search.ts
@@ -39,10 +39,12 @@ const BROAD_SEARCH_TIMEOUT_MAX_SEC = 300;
 /** Tool advertisement — clients see this in the list-tools response. */
 export const searchTool: Tool = {
   name: "search",
+  title: "Web Search",
   // Explicit MCP tool annotations: every Octen tool is a read-only query
   // against the open web — it fetches and never mutates external state.
   // Plugin-directory reviews require these three hints on every tool.
   annotations: {
+    title: "Web Search",
     readOnlyHint: true,
     openWorldHint: true,
     destructiveHint: false,
@@ -204,7 +206,9 @@ const { topic: _omitTopic, ...newsProperties } =
 
 export const newsSearchTool: Tool = {
   name: "news_search",
+  title: "News Search",
   annotations: {
+    title: "News Search",
     readOnlyHint: true,
     openWorldHint: true,
     destructiveHint: false,
@@ -351,7 +355,9 @@ const { query: broadQueryProp, ...broadOptionProperties } = broadBaseProperties;
 
 export const broadSearchTool: Tool = {
   name: "broad_search",
+  title: "Broad Search",
   annotations: {
+    title: "Broad Search",
     readOnlyHint: true,
     openWorldHint: true,
     destructiveHint: false,

--- a/src/videoSearch.ts
+++ b/src/videoSearch.ts
@@ -23,10 +23,12 @@ const API_KEY = process.env.OCTEN_API_KEY;
 /** Tool advertisement — clients see this in the list-tools response. */
 export const videoSearchTool: Tool = {
   name: "video_search",
+  title: "Video Search",
   // Explicit MCP tool annotations: every Octen tool is a read-only query
   // against the open web — it fetches and never mutates external state.
   // Plugin-directory reviews require these three hints on every tool.
   annotations: {
+    title: "Video Search",
     readOnlyHint: true,
     openWorldHint: true,
     destructiveHint: false,

--- a/test/annotations.test.mjs
+++ b/test/annotations.test.mjs
@@ -43,4 +43,14 @@ for (const tool of tools) {
     // The shape must be valid per the MCP spec, not just truthy.
     ToolSchema.parse(tool);
   });
+
+  // Connector-directory reviews require a human-readable title on every tool.
+  // Set it both top-level (MCP 2025-06-18 BaseMetadata) and in annotations
+  // (the classic location) so every client generation can read it.
+  test(`${tool.name} declares a human-readable title in both locations`, () => {
+    assert.equal(typeof tool.title, "string", `${tool.name} top-level title`);
+    assert.ok(tool.title.trim().length > 0, `${tool.name} title must be non-empty`);
+    assert.equal(tool.annotations.title, tool.title,
+      `${tool.name} annotations.title must match the top-level title`);
+  });
 }


### PR DESCRIPTION
Prep for the Claude Connectors Directory submission: its requirements state every tool must include a `title` plus the applicable `readOnlyHint`/`destructiveHint` (hints landed in #23), and the submission portal's Tools step flags tools with missing titles as must-fix before submitting.

| Tool | Title |
|--|--|
| `search` | Web Search |
| `news_search` | News Search |
| `broad_search` | Broad Search |
| `extract` | URL Extract |
| `image_search` | Image Search |
| `video_search` | Video Search |

The title is set in BOTH locations — top-level `Tool.title` (MCP 2025-06-18 BaseMetadata) and `annotations.title` (the classic pre-2025-06 location) — with identical values, so old and new client generations both read it. Tests pin presence, non-emptiness, and equality of the two (red first, then green); full suite **195/195**; verified end-to-end over stdio `tools/list` (the HTTP transport serves the same tool objects).

Version bumped to 0.5.2. After merge: tag `v0.5.2` → npm + ACR image pipelines → redeploy mcp.octen.ai so the Claude portal's tool sync sees the titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)